### PR TITLE
Reemplace property min-width value

### DIFF
--- a/lms/static/sass/base/_layouts.scss
+++ b/lms/static/sass/base/_layouts.scss
@@ -66,7 +66,7 @@ body.view-incourse {
   // post-container footer (creative commons)
   .container-footer {
     max-width: none;
-    min-width: none;
+    min-width: 0;
     width: auto;
   }
 


### PR DESCRIPTION
The min-width property accept only values <length> | <percentage> | inherit. to reset better set to 0.
Properties documentation: https://www.w3.org/TR/CSS2/visudet.html#min-max-widths

This error generates an invalid style, and, therefore, this value is set to 760px by: https://github.com/edx/edx-platform/blob/master/lms/static/sass/course/courseware/_courseware.scss#L50