### PR TITLE
Allow theme template block override

### DIFF
--- a/common/djangoapps/edxmako/paths.py
+++ b/common/djangoapps/edxmako/paths.py
@@ -70,6 +70,11 @@ class DynamicTemplateLookup(TemplateLookup):
             try:
                 # Try to find themed template, i.e. see if current theme overrides the template
                 template = super(DynamicTemplateLookup, self).get_template(get_template_path_with_theme(uri))
+                # For an overriding template, the uri is the path to the same template, so the lookup always
+                # finds the same overriding template. If that's the case, route to exception so that the
+                # uri can be stripped of the path and the parent template can be found.
+                if template == super(DynamicTemplateLookup, self).get_template(uri):
+                    raise TopLevelLookupException()
             except TopLevelLookupException:
                 # strip off the prefix path to theme and look in default template dirs
                 template = super(DynamicTemplateLookup, self).get_template(strip_site_theme_templates_path(uri))

--- a/common/test/test-theme/lms/templates/dashboard.html
+++ b/common/test/test-theme/lms/templates/dashboard.html
@@ -1,0 +1,4 @@
+<%inherit file="dashboard.html" />
+<%block name="pagetitle">Overridden Title!</%block>
+${parent.body()}
+<%block name="bodyextra">Overriden Body Extra!</%block>

--- a/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
+++ b/openedx/core/djangoapps/theming/tests/test_theme_style_overrides.py
@@ -64,6 +64,30 @@ class TestComprehensiveThemeLMS(TestCase):
         result = staticfiles.finders.find('test-theme/images/logo.png')
         self.assertEqual(result, settings.TEST_THEME / 'lms/static/images/logo.png')
 
+    @with_comprehensive_theme("test-theme")
+    def test_override_block_in_parent(self):
+        """
+        Test that theme title is used instead of parent title.
+        """
+        self._login()
+        dashboard_url = reverse('dashboard')
+        resp = self.client.get(dashboard_url)
+        self.assertEqual(resp.status_code, 200)
+        # This string comes from the 'pagetitle' block of the overriding theme.
+        self.assertContains(resp, "Overridden Title!")
+
+    @with_comprehensive_theme("test-theme")
+    def test_override_block_in_grandparent(self):
+        """
+        Test that theme title is used instead of parent's parent's title.
+        """
+        self._login()
+        dashboard_url = reverse('dashboard')
+        resp = self.client.get(dashboard_url)
+        self.assertEqual(resp.status_code, 200)
+        # This string comes from the 'bodyextra' block of the overriding theme.
+        self.assertContains(resp, "Overriden Body Extra!")
+
 
 @skip_unless_cms
 class TestComprehensiveThemeCMS(TestCase):


### PR DESCRIPTION
## Description

This PR is a feature already added in master upstream that allows overriding a template block. This is the PR already merged in master: https://github.com/edx/edx-platform/pull/15947. We need to add it to our ginkgo master.

## How to test (textually from original PR)

1. Create a test theme:

- make a directory /edx/app/edxapp/themes/testtheme

- create a template at /edx/app/edxapp/themes/testtheme/lms/templates/dashboard.html, and put this content into it:
```
<%inherit file="dashboard.html" />
<%block name="pagetitle">Overridden Title!</%block>
${parent.body()}
```
If you want, you could add other blocks like `<%block name="bodyextra">Overriden Body Extra!</%block>`

2. In devstatck settings:
```
COMPREHENSIVE_THEME_DIRS: ["/edx/app/edxapp/themes"]
ENABLE_COMPREHENSIVE_THEMING: true
DEFAULT_SITE_THEME: "testtheme"
```
After you restart the LMS, you should be able to see "Overriddden Title!" used as the page title on the student dashboard, if the patch is working correctly.

Maybe you need delete cache:
`rm -rf /tmp/mako_* `
`sudo service memcached restart.`

## Reviewers
- [ ] @felipemontoya 
- [ ] @diegomillan 