### PR TITLE
CAM2-103 - Fix issue with RTL support on mobile views. 

### DIFF
--- a/lms/templates/main.html
+++ b/lms/templates/main.html
@@ -141,7 +141,7 @@ from pipeline_mako import render_require_js_path_overrides
         <%include file="/preview_menu.html" />
     % endif
 
-    <div class="content-wrapper ${"container-fluid" if uses_bootstrap else "" } main-container" id="content">
+    <div class="content-wrapper ${"container-fluid" if uses_bootstrap else "" } main-container" id="content" dir="${static.dir_rtl()}">
       ${self.body()}
       <%block name="bodyextra"/>
     </div>


### PR DESCRIPTION
### Description
This PR is submit according to JIRA CAM2-103, wich solved a issue with RTL support on mobile views (Android - iOS).

This only add a dir attribute that it is not set in content-wrapper div depending on language configuration (LTR - RTL).

### Test
Open some course unit on a mobile device (Android - iOS) with RTL language configuration.

### Screenshots
RTL issue
![rtl-issue-1](https://user-images.githubusercontent.com/17520199/45565229-9eef2a00-b818-11e8-82f2-4a17181ef5b1.jpg)
RTL fixed
![rtl-fix-1](https://user-images.githubusercontent.com/17520199/45565227-9eef2a00-b818-11e8-8f3b-41f35e8505a1.jpg)
RTL issue
![rtl-issue-2](https://user-images.githubusercontent.com/17520199/45565230-9f87c080-b818-11e8-84d3-7c6104bc52f9.jpg)
RTL fixed
![rtl-fix-2](https://user-images.githubusercontent.com/17520199/45565228-9eef2a00-b818-11e8-949a-f768548c30cc.jpg)
