### PR TITLE
Add custom form fields to account settings page - HAW/CAMROM-007

### DIFF
--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -36,6 +36,9 @@ from .serializers import (
     UserReadOnlySerializer, _visible_fields  # pylint: disable=invalid-name
 )
 
+# Import custom form model from campusromero_openedx_extensions plugin app.
+from campusromero_openedx_extensions.custom_registration_form.models import CustomFormFields
+
 # Public access point for this function.
 visible_fields = _visible_fields
 
@@ -239,10 +242,18 @@ def update_account_settings(requesting_user, update, username=None):
         if 'extended_profile' in update:
             meta = existing_user_profile.get_meta()
             new_extended_profile = update['extended_profile']
+            # We get the custom form fields by user.
+            custom_form_fields_obj = CustomFormFields.objects.get(user=existing_user)
             for field in new_extended_profile:
                 field_name = field['field_name']
                 new_value = field['field_value']
-                meta[field_name] = new_value
+                if field_name in meta:
+                    meta[field_name] = new_value
+                # If field_name does not exist in meta we check that
+                # exist in custom_form_fields_obj and then we save it.
+                elif hasattr(custom_form_fields_obj, field_name):
+                    setattr(custom_form_fields_obj, field_name, new_value)
+            custom_form_fields_obj.save()
             existing_user_profile.set_meta(meta)
             existing_user_profile.save()
 


### PR DESCRIPTION
## Description

This PR adds the custom registration fields added in [campusromero-openedx-extensions PR](https://github.com/eduNEXT/campusromero-openedx-extensions/pull/1) to the account settings page inside the lms.

## Configuration

Same as the [campusromero-openedx-extensions PR](https://github.com/eduNEXT/campusromero-openedx-extensions/pull/1)

## Screenshots

![image](https://user-images.githubusercontent.com/17520199/47120518-9e411d80-d234-11e8-907f-e5936d303b87.png)


## Reviewers:

- [ ] @jfavellar90 
- [ ] @Alec4r 
- [ ] @felipemontoya 