### PR TITLE
Add new api endpoint - CAMROM-022

### DIFF
--- a/openedx/core/djangoapps/user_api/preferences/views.py
+++ b/openedx/core/djangoapps/user_api/preferences/views.py
@@ -4,14 +4,21 @@ An API for retrieving user preference information.
 For additional information and historical context, see:
 https://openedx.atlassian.net/wiki/display/TNL/User+API
 """
-from rest_framework.views import APIView
-from rest_framework.response import Response
+import uuid
+
+from edx_rest_framework_extensions.authentication import JwtAuthentication
 from rest_framework import status
 from rest_framework import permissions
+from rest_framework.authentication import SessionAuthentication
+from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from django.db import transaction
+from django.http import JsonResponse
+from django.contrib.auth.models import User
 from django.utils.translation import ugettext as _
 
+from lms.djangoapps.verify_student.models import SoftwareSecurePhotoVerification
 from openedx.core.lib.api.authentication import (
     SessionAuthenticationAllowInactiveUser,
     OAuth2AuthenticationAllowInactiveUser,
@@ -263,3 +270,59 @@ class PreferencesDetailView(APIView):
             return Response(status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class ChangeToVerifiedMode(APIView):
+    """
+    Change the status to 'approved' in Software Secure Photo Verification model for the given user.
+    """
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+
+    def post(self, request):
+        """
+        Change the status of the user into Software Secure Photo Verification model,
+        if it not exist, is created instead with status value 'approved' by default.
+
+        Receive a username key, with the username value to change status.
+
+        POST api/user/v1/preferences/change_to_verified_mode/
+
+        Returns:
+            Json object that contains two keys: status and username.
+
+            - status: Inidicate the operation status, created, updated or user does not exist error.
+            - username: Contains the username provided in post request.
+        """
+        if not request.data.get('username'):
+            return JsonResponse({
+                'status': 'No username key provided.',
+                'username': ''
+            }, status=status.HTTP_400_BAD_REQUEST)
+
+        username = request.data['username']
+        operation_status = 'updated'
+        try:
+            user_info = User.objects.get(username=username)
+        except User.DoesNotExist:
+            return JsonResponse({
+                'status': 'The user with username: {}, does not exist.'.format(username),
+                'username': username
+            }, status=status.HTTP_404_NOT_FOUND)
+        try:
+            user_photo_verification = SoftwareSecurePhotoVerification.objects.get(user_id=user_info.id)
+            user_photo_verification.status = 'approved'
+            user_photo_verification.save()
+        except SoftwareSecurePhotoVerification.DoesNotExist:
+            operation_status = 'created'
+            receipt_id = str(uuid.uuid4())
+            user_photo_verification = SoftwareSecurePhotoVerification(
+                status='approved',
+                receipt_id=receipt_id,
+                user_id=user_info.id
+            )
+            user_photo_verification.save()
+        return JsonResponse({
+            'status': operation_status,
+            'username': username
+        }, status=status.HTTP_200_OK)

--- a/openedx/core/djangoapps/user_api/urls.py
+++ b/openedx/core/djangoapps/user_api/urls.py
@@ -16,7 +16,7 @@ from .accounts.views import (
     DeactivateLogoutView,
     LMSAccountRetirementView
 )
-from .preferences.views import PreferencesDetailView, PreferencesView
+from .preferences.views import PreferencesDetailView, PreferencesView, ChangeToVerifiedMode
 from .verification_api.views import IDVerificationStatusView
 from .validation.views import RegistrationValidationView
 
@@ -153,5 +153,10 @@ urlpatterns = [
         r'^v1/preferences/{}/(?P<preference_key>[a-zA-Z0-9_]+)$'.format(settings.USERNAME_PATTERN),
         PreferencesDetailView.as_view(),
         name='preferences_detail_api'
+    ),
+    url(
+        r'^v1/preferences/change_to_verified_mode/$',
+        ChangeToVerifiedMode.as_view(),
+        name='change_to_verified_mode'
     ),
 ]


### PR DESCRIPTION
## Description:

This PR adds a new api endpoint, in order to add or change the 'status' field of the provided student in the SoftwareSecurePhotoVerification model.

POST api/user/v1/preferences/change_to_verified_mode/

{
    'username': username_to_change
}

This endpoint it will be used from the eCommerce site, with a JWT valid token.

## Revievers

- [ ] @jfavellar90 
- [ ] @Alec4r 

@Ivanca 