### PR TITLE
Making the include function used to support static .underscore templa…

### DIFF
--- a/common/djangoapps/pipeline_mako/templates/static_content.html
+++ b/common/djangoapps/pipeline_mako/templates/static_content.html
@@ -82,7 +82,12 @@ except:
 from django.conf import settings
 from django.template.engine import Engine
 from django.template.loaders.filesystem import Loader
-engine = Engine(dirs=settings.DEFAULT_TEMPLATE_ENGINE['DIRS'])
+from openedx.core.djangoapps.theming.helpers import get_current_theme
+dirs = settings.DEFAULT_TEMPLATE_ENGINE['DIRS']
+theme = get_current_theme()
+if theme:
+    dirs.insert(0, theme.path / 'templates')
+engine = Engine(dirs=dirs)
 source, template_path = Loader(engine).load_template_source(path)
 %>${source | n, decode.utf8}</%def>
 


### PR DESCRIPTION
@felipemontoya @jfavellar90 

Making the include function used to support static .underscore templates support comprehensive_theming in ginkgo+azure instances

I will create the PR in cruise control