### PR TITLE
Making the SESSION_COOKIE_DOMAIN support multi-tenants

### DIFF
--- a/common/djangoapps/student/cookies.py
+++ b/common/djangoapps/student/cookies.py
@@ -14,6 +14,7 @@ from django.dispatch import Signal
 from django.utils.http import cookie_date
 
 from openedx.core.djangoapps.user_api.accounts.utils import retrieve_last_sitewide_block_completed
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from student.models import CourseEnrollment
 
 CREATE_LOGON_COOKIE = Signal(providing_args=['user', 'response'])
@@ -33,7 +34,7 @@ def standard_cookie_settings(request):
     cookie_settings = {
         'max_age': max_age,
         'expires': expires,
-        'domain': settings.SESSION_COOKIE_DOMAIN,
+        'domain': configuration_helpers.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN),
         'path': '/',
         'httponly': None,
     }
@@ -204,7 +205,7 @@ def delete_logged_in_cookies(response):
         response.delete_cookie(
             cookie_name.encode('utf-8'),
             path='/',
-            domain=settings.SESSION_COOKIE_DOMAIN
+            domain=configuration_helpers.get_value('SESSION_COOKIE_DOMAIN', settings.SESSION_COOKIE_DOMAIN)
         )
 
     return response


### PR DESCRIPTION
This PR makes a couple of cookie features microsite aware:

- Making the SESSION_COOKIE_DOMAIN support multi-tenants
- Removing the mktg cookies is site aware now

@morenol 
@felipemontoya 
