### PR TITLE
Making student account deletion components a bit site aware

### DIFF
--- a/lms/static/js/student_account/StudentAccountDeletionInitializer.js
+++ b/lms/static/js/student_account/StudentAccountDeletionInitializer.js
@@ -16,7 +16,13 @@ const wrapperRendered = setInterval(() => {
       component: StudentAccountDeletion,
       selector: `#${accountDeletionWrapperId}`,
       componentName: 'StudentAccountDeletion',
-      props: { socialAccountLinks: window.auth, isActive: window.isActive },
+      props: {
+        socialAccountLinks: window.auth,
+        isActive: window.isActive,
+        platformName: window.platformName,
+        siteName: window.siteName,
+        lmsUrlRoot: window.lmsUrlRoot
+      },
     });
   }
 

--- a/lms/static/js/student_account/components/StudentAccountDeletion.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletion.jsx
@@ -64,11 +64,26 @@ export class StudentAccountDeletion extends React.Component {
       },
     );
 
+    const noteDeletion = StringUtils.interpolate(
+      gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. {platformName} will not be able to recover your account or the data that is deleted.'),
+      {
+        platformName: this.props.platformName,
+      },
+    );
+
+    const bodyDeletion = StringUtils.interpolate(
+      gettext('Once your account is deleted, you cannot use it to take courses on the {platformName} app, {siteName}, or any other site hosted by {platformName}.'),
+      {
+        platformName: this.props.platformName,
+        siteName: this.props.siteName,
+      },
+    );
+
     return (
       <div className="account-deletion-details">
         <p className="account-settings-header-subtitle">{ gettext('We’re sorry to see you go!') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Please note: Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</p>
-        <p className="account-settings-header-subtitle">{ gettext('Once your account is deleted, you cannot use it to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+        <p className="account-settings-header-subtitle">{noteDeletion}</p>
+        <p className="account-settings-header-subtitle">{bodyDeletion}</p>
         <p
           className="account-settings-header-subtitle"
           dangerouslySetInnerHTML={{ __html: loseAccessText }}
@@ -102,7 +117,12 @@ export class StudentAccountDeletion extends React.Component {
             open
           />
         }
-        {deletionModalOpen && <StudentAccountDeletionModal onClose={this.closeDeletionModal} />}
+        {deletionModalOpen && <StudentAccountDeletionModal
+                                onClose={this.closeDeletionModal}
+                                platformName={this.props.platformName}
+                                siteName={this.props.siteName}
+                                lmsUrlRoot={this.props.lmsUrlRoot}
+                              />}
       </div>
     );
   }
@@ -113,4 +133,7 @@ StudentAccountDeletion.propTypes = {
   socialAccountLinks: PropTypes.shape({
     providers: PropTypes.arrayOf(PropTypes.object),
   }).isRequired,
+  platformName: PropTypes.string,
+  siteName: PropTypes.string,
+  lmsUrlRoot: PropTypes.string,
 };

--- a/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
+++ b/lms/static/js/student_account/components/StudentAccountDeletionModal.jsx
@@ -31,7 +31,7 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
     this.props.onClose();
 
     removeLoggedInCookies();
-    window.location.href = 'https://www.edx.org';
+    window.location.href = this.props.lmsUrlRoot;
   }
 
   deleteAccount() {
@@ -101,6 +101,21 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
       },
     );
 
+    const noteDeletion = StringUtils.interpolate(
+      gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. {platformName} will not be able to recover your account or the data that is deleted.'),
+      {
+        platformName: this.props.platformName,
+      },
+    );
+
+    const bodyDeletion = StringUtils.interpolate(
+      gettext('If you proceed, you will be unable to use this account to take courses on the {platformName} app, {siteName}, or any other site hosted by {platformName}.'),
+      {
+        platformName: this.props.platformName,
+        siteName: this.props.siteName,
+      },
+    );
+
     return (
       <div className="delete-confirmation-wrapper">
         <Modal
@@ -137,8 +152,8 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
                       <Icon id="delete-confirmation-body-warning-icon" className={['fa', 'fa-exclamation-triangle']} />
                     </div>
                     <div className="alert-content">
-                      <h3 className="alert-title">{ gettext('You have selected “Delete my account.” Deletion of your account and personal data is permanent and cannot be undone. EdX will not be able to recover your account or the data that is deleted.') }</h3>
-                      <p>{ gettext('If you proceed, you will be unable to use this account to take courses on the edX app, edx.org, or any other site hosted by edX. This includes access to edx.org from your employer’s or university’s system and access to private sites offered by MIT Open Learning, Wharton Executive Education, and Harvard Medical School.') }</p>
+                      <h3 className="alert-title">{noteDeletion}</h3>
+                      <p>{bodyDeletion}</p>
                       <p dangerouslySetInnerHTML={{ __html: loseAccessText }} />
                     </div>
                   </div>
@@ -198,10 +213,16 @@ class StudentAccountDeletionConfirmationModal extends React.Component {
 
 StudentAccountDeletionConfirmationModal.propTypes = {
   onClose: PropTypes.func,
+  platformName: PropTypes.string,
+  siteName: PropTypes.string,
+  lmsUrlRoot: PropTypes.string,
 };
 
 StudentAccountDeletionConfirmationModal.defaultProps = {
   onClose: () => {},
+  platformName: "",
+  siteName: "",
+  lmsUrlRoot: "",
 };
 
 export default StudentAccountDeletionConfirmationModal;

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -72,6 +72,9 @@ from webpack_loader.templatetags.webpack_loader import render_bundle
 <script type="text/javascript">
      window.auth = ${ auth | n, dump_js_escaped_json };
      window.isActive = ${ user.is_active | n, dump_js_escaped_json };
+     window.platformName = "${ platform_name | n, js_escaped_string }";
+     window.siteName = "${static.get_value('SITE_NAME', settings.SITE_NAME)}";
+     window.lmsUrlRoot = "${static.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL)}";
 </script>
 <%static:webpack entry="StudentAccountDeletionInitializer">
 </%static:webpack>


### PR DESCRIPTION
This PR basically changes a bit the messages displayed by the retirement users components. These components now receive a couple of parameters to build the messages to render

@Ivanca 
@felipemontoya 