### PR TITLE
Fixing bug when SetBrandingByReferer is None

### DIFF
--- a/lms/djangoapps/branding_by_referer/branding_by_referer.py
+++ b/lms/djangoapps/branding_by_referer/branding_by_referer.py
@@ -81,7 +81,7 @@ class SetBrandingByReferer(MiddlewareMixin):
 
 def get_branding_referer_url_for_current_user():
     """ get valid referer url saved for this user """
-    if not hasattr(SetBrandingByReferer, 'user_referer'):
+    if not getattr(SetBrandingByReferer, 'user_referer', None):
         return None
     return '//{}'.format(getattr(SetBrandingByReferer, 'user_referer'))
 


### PR DESCRIPTION
Checking existence of attribute is not enough, we must check it is not None as well. 
This bug was making that the home logo redirects to "https://none", fixed on this PR. 