### PR TITLE
customizing student account options and settings

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -415,7 +415,7 @@ class UserProfile(models.Model):
 
     # Optional demographic data we started capturing from Fall 2012
     this_year = datetime.now(UTC).year
-    VALID_YEARS = range(this_year, this_year - 120, -1)
+    VALID_YEARS = range(this_year - 16, this_year - 120, -1)
     year_of_birth = models.IntegerField(blank=True, null=True, db_index=True)
     GENDER_CHOICES = (
         ('m', ugettext_noop('Male')),

--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -540,7 +540,7 @@ def account_settings_context(request):
         'nav_hidden': True,
         'fields': {
             'country': {
-                'options': list(countries),
+                'options': [(u'UY', u'Uruguay')],  # For all options use list(countries)
             }, 'gender': {
                 'options': [(choice[0], _(choice[1])) for choice in UserProfile.GENDER_CHOICES],  # pylint: disable=translation-of-non-string
             }, 'language': {
@@ -552,7 +552,7 @@ def account_settings_context(request):
             }, 'year_of_birth': {
                 'options': year_of_birth_options,
             }, 'preferred_language': {
-                'options': all_languages(),
+                'options': [(u'es', u'Espanol')],  # for all options use all_languages()
             }, 'time_zone': {
                 'options': TIME_ZONE_CHOICES,
             }

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -143,19 +143,19 @@
                         },
                         fullnameFieldView,
                         emailFieldView,
-                        {
-                            view: new AccountSettingsFieldViews.PasswordFieldView({
-                                model: userAccountModel,
-                                title: gettext('Password'),
-                                screenReaderTitle: gettext('Reset Your Password'),
-                                valueAttribute: 'password',
-                                emailAttribute: 'email',
-                                passwordResetSupportUrl: passwordResetSupportUrl,
-                                linkTitle: gettext('Reset Your Password'),
-                                linkHref: fieldsData.password.url,
-                                helpMessage: gettext('Check your email account for instructions to reset your password.')  // eslint-disable-line max-len
-                            })
-                        },
+                        // {
+                        //     view: new AccountSettingsFieldViews.PasswordFieldView({
+                        //         model: userAccountModel,
+                        //         title: gettext('Password'),
+                        //         screenReaderTitle: gettext('Reset Your Password'),
+                        //         valueAttribute: 'password',
+                        //         emailAttribute: 'email',
+                        //         passwordResetSupportUrl: passwordResetSupportUrl,
+                        //         linkTitle: gettext('Reset Your Password'),
+                        //         linkHref: fieldsData.password.url,
+                        //         helpMessage: gettext('Check your email account for instructions to reset your password.')  // eslint-disable-line max-len
+                        //     })
+                        // },
                         {
                             view: new AccountSettingsFieldViews.LanguagePreferenceFieldView({
                                 model: userPreferencesModel,

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -23,14 +23,14 @@
                     selected: true,
                     expanded: true
                 },
-                {
-                    name: 'accountsTabSections',
-                    id: 'accounts-tab',
-                    label: gettext('Linked Accounts'),
-                    tabindex: -1,
-                    selected: false,
-                    expanded: false
-                },
+                // {
+                //     name: 'accountsTabSections',
+                //     id: 'accounts-tab',
+                //     label: gettext('Linked Accounts'),
+                //     tabindex: -1,
+                //     selected: false,
+                //     expanded: false
+                // },
                 {
                     name: 'ordersTabSections',
                     id: 'orders-tab',


### PR DESCRIPTION
customizing student account options and settings

@Alec4r 

This PR modifies a bit the user account page:
* Removes the option for restoring the password
* Only Uruguay can be select as country
* Only Spanish can be selected as language
* It's not possible to associate third party accounts (Google, Facebook, Linkedin, etc)