### PR TITLE
Temporal fix: slow program pages responses

### DIFF
--- a/lms/templates/learner_dashboard/course_enroll.underscore
+++ b/lms/templates/learner_dashboard/course_enroll.underscore
@@ -1,7 +1,13 @@
 <% if (is_enrolled && collectionCourseStatus === 'completed') { %>
     <div class="final-grade">
         <div class="grade-header"><%- gettext('Final Grade') %><span class="sr"><%- StringUtils.interpolate(gettext('for {courseName}'), {courseName: title}) %></span></div>
-        <div class="grade-display"><%- grade %>%</div>
+        <div class="grade-display">
+            <% if (grade) { %>
+                <%- grade %>%
+            <% } else { %>
+                gettext('Not available')
+            <% } %>
+        </div>
     </div>
 <% } else if (is_enrolled && (typeof expired === 'undefined' || expired === false)) { %>
     <a href="<%- course_url %>" class="view-course-button btn-brand btn cta-primary">

--- a/openedx/core/djangoapps/programs/utils.py
+++ b/openedx/core/djangoapps/programs/utils.py
@@ -261,9 +261,10 @@ class ProgramProgressMeter(object):
                     not_started.append(course)
 
             grades = {}
-            for run in self.course_run_ids:
-                grade = self.course_grade_factory.read(self.user, course_key=CourseKey.from_string(run))
-                grades[run] = grade.percent
+            if configuration_helpers.get_value('program_progress_meter_read_grades', False):
+                for run in self.course_run_ids:
+                    grade = self.course_grade_factory.read(self.user, course_key=CourseKey.from_string(run))
+                    grades[run] = grade.percent
 
             progress.append({
                 'uuid': program_copy['uuid'],


### PR DESCRIPTION
The fact that a program progress meter instance read or not the user grades is configured via a waffle flag. This is considered a temporal fix till we complete the back fill of the persistent grades on LLPA. With this fix program pages will be served quick.

@felipemontoya 
@Squirrel18 
@diegomillan 
