### PR TITLE
Moving all the logic to the plugin

### DIFF
--- a/lms/djangoapps/student_account/views.py
+++ b/lms/djangoapps/student_account/views.py
@@ -60,8 +60,6 @@ from util.date_utils import strftime_localized
 
 # Import custom form model from llpa_openedx_extensions plugin app developed by eduNext.
 from llpa_openedx_extensions.custom_registration_form.models import CustomFormFields
-# Import view from plugin to get the fields from the custom form model.
-from llpa_openedx_extensions.custom_registration_form.views import _get_custom_form_fields
 
 AUDIT_LOG = logging.getLogger("audit")
 log = logging.getLogger(__name__)
@@ -578,7 +576,7 @@ def account_settings_context(request):
     }
 
     # We extend the extended_profile_fields and maintain data no related to custom form fields.
-    context['extended_profile_fields'].extend(_get_custom_form_fields(CustomFormFields))
+    context['extended_profile_fields'].extend(CustomFormFields.get_fields())
 
     enterprise_customer = get_enterprise_customer_for_learner(site=request.site, user=request.user)
     update_account_settings_context_for_enterprise(context, enterprise_customer)

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -242,31 +242,14 @@ def update_account_settings(requesting_user, update, username=None):
         if 'extended_profile' in update:
             meta = existing_user_profile.get_meta()
             new_extended_profile = update['extended_profile']
-            # We get the custom form fields by user.
-            try:
-                custom_form_fields_obj = CustomFormFields.objects.get(user=existing_user)
-            except CustomFormFields.DoesNotExist:
-                custom_form_fields_obj = CustomFormFields(
-                    user=existing_user,
-                    consent_employer='NO',
-                    consent_microsoft='NO',
-                    consent_llpa='NO'
-                )
-            save_custom_form_fields = False
+            new_extended_profile = CustomFormFields.save_extended(existing_user, new_extended_profile)
             for field in new_extended_profile:
                 field_name = field['field_name']
                 new_value = field['field_value']
-                # If field_name exists in custom_form_fields_obj, set it there,
-                # otherwise, set it on user profile meta.
-                if hasattr(custom_form_fields_obj, field_name):
-                    setattr(custom_form_fields_obj, field_name, new_value)
-                    save_custom_form_fields = True
-                else:
-                    meta[field_name] = new_value
-            if save_custom_form_fields:
-                custom_form_fields_obj.save()
+                meta[field_name] = new_value
             existing_user_profile.set_meta(meta)
             existing_user_profile.save()
+
 
     except PreferenceValidationError as err:
         raise AccountValidationError(err.preference_errors)

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -30,7 +30,6 @@ from .image_helpers import get_profile_image_urls_for_user
 from .utils import validate_social_link, format_social_link
 
 # Import custom form model and view from llpa openedx extensions plugin app.
-from llpa_openedx_extensions.custom_registration_form.views import get_custom_form_fields_by_user
 from llpa_openedx_extensions.custom_registration_form.models import CustomFormFields
 
 PROFILE_IMAGE_KEY_PREFIX = 'image_url'
@@ -436,7 +435,7 @@ def get_extended_profile(user_profile):
             "field_name": field_name,
             "field_value": extended_profile_fields_data.get(field_name, "")
         })
-    extended_profile.extend(get_custom_form_fields_by_user(user_profile.user, CustomFormFields))
+    extended_profile.extend(CustomFormFields.get_fields(user=user_profile.user))
     return extended_profile
 
 


### PR DESCRIPTION
This PR removes some of the logic of storing the CustomRegistrationForm fields and moves it back to the plugin