### PR TITLE
LLPA-26: Adding help message to custom fields from js

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -252,6 +252,7 @@
                             view: new AccountSettingsFieldViews.ExtendedFieldListFieldView({
                                 model: userAccountModel,
                                 title: fieldItem.field_label,
+                                helpMessage: fieldItem.field_message,  // eslint-disable-line max-len,
                                 fieldName: fieldItem.field_name,
                                 options: fieldItem.field_options,
                                 valueAttribute: 'extended_profile',


### PR DESCRIPTION
The help message in the account settings page is set from the platform java script. By default, the help message is not set for extended fields (which include the custom fields). 

I added the helpMessage to the js, this reads the field_message attribute that I created for the custom fields in the plugin (see this PR https://bitbucket.org/edunext/llpa_openedx_extensions/pull-requests/3/adding-help-messages-to-custom-fields/diff).

Since I created the field_message, I'm not sure if this could create conflict with other extended fields that don't have this attribute. What do you think? @amalbas @felipemontoya 

I tested this in dev and works correctly.
