### PR TITLE
Adding autocomplete off to login form

### DIFF
--- a/lms/templates/student_account/login.underscore
+++ b/lms/templates/student_account/login.underscore
@@ -27,7 +27,7 @@
     <h2><%- gettext("Sign In") %></h2>
 <% } %>
 
-<form id="login" class="login-form" tabindex="-1" method="POST">
+<form id="login" class="login-form" autocomplete="off" tabindex="-1" method="POST">
 
     <p class="sr">
         <% if ( context.providers.length > 0 && !context.currentProvider || context.hasSecondaryProviders ) { %>


### PR DESCRIPTION
According to the report they sent (see ticket 7716), the `autocomplete off` is not  set in the login and registration forms, but open edx has the autocomplete off by default in the registration form.

So, I think they expect the autocomplete off to be set also at the username and password fields. This is not as easy to do and may require JS.

I'm adding the autocomplete="off" to the entire form for now, but I don't think their security test will pass with only this change.