### PR TITLE
Enabling search in django admin for user preferences.

### DIFF
--- a/openedx/core/djangoapps/user_api/admin.py
+++ b/openedx/core/djangoapps/user_api/admin.py
@@ -51,6 +51,11 @@ class UserPreferenceAdmin(admin.ModelAdmin):
     Admin interface for the UserPreference model.
     """
     list_display = ('user', 'key', 'value',)
+    search_fields = (
+        'key',
+        'user__username',
+        'user__email',
+    )
 
     class Meta(object):
         model = UserPreference


### PR DESCRIPTION
Enabling searching of a user at the user preference table in django admin.

As requested in ticket 7859