### PR TITLE
Lmm/updatesga

### DIFF
--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -20,7 +20,7 @@ git+https://github.com/edx/django-rest-framework-oauth.git@0a43e8525f1e3048efe4b
 git+https://github.com/edx/django-rest-framework.git@1ceda7c086fddffd1c440cc86856441bbf0bd9cb#egg=djangorestframework==3.6.3
 -e git+https://github.com/edx/DoneXBlock.git@01a14f3bd80ae47dd08cdbbe2f88f3eb88d00fba#egg=done-xblock
 -e git+https://github.com/jazkarta/edx-jsme.git@690dbf75441fa91c7c4899df0b83d77f7deb5458#egg=edx-jsme
-git+https://github.com/mitodl/edx-sga.git@3828ba9e413080a81b907a3381e5ffa05e063f81#egg=edx-sga==0.8.3
+git+https://github.com/edunext/edx-sga.git@97d41c3fcc3c641a9ed5262b9f4cec0589a06b50#egg=edx-sga==0.8.3.ednx
 git+https://github.com/edx/xblock-lti-consumer.git@v1.1.8#egg=lti_consumer-xblock==1.1.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 -e .


### PR DESCRIPTION
Change applied on: https://github.com/eduNEXT/edunext-platform/pull/358

This change allows us to copy units with the edx-sga xblock.

