### PR TITLE
Fix unregistered task

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -901,7 +901,11 @@ WEBPACK_CONFIG_PATH = 'webpack.prod.config.js'
 ################################# CELERY ######################################
 
 # Auto discover tasks fails to detect contentstore tasks
-CELERY_IMPORTS = ('cms.djangoapps.contentstore.tasks')
+CELERY_IMPORTS = (
+    'cms.djangoapps.contentstore.tasks',
+    'openedx.core.djangoapps.bookmarks.tasks',
+    'openedx.core.djangoapps.ccxcon.tasks',
+)
 
 # Message configuration
 

--- a/openedx/core/djangoapps/ccxcon/tasks.py
+++ b/openedx/core/djangoapps/ccxcon/tasks.py
@@ -12,7 +12,7 @@ from openedx.core.djangoapps.ccxcon import api
 log = get_task_logger(__name__)
 
 
-@task()
+@task(name='openedx.core.djangoapps.ccxcon.tasks.update_ccxcon')
 def update_ccxcon(course_id, cur_retry=0):
     """
     Pass through function to update course information on CCXCon.


### PR DESCRIPTION
openedx.core.djangoapps.ccxcon.tasks.update_ccxcon is not get auto
discovered by celery. Adding it to CELERY_IMPORTS to be explicitly
added.
