### PR TITLE
Change the deprecated log.warn method

### DIFF
--- a/openedx/core/djangoapps/enrollments/api.py
+++ b/openedx/core/djangoapps/enrollments/api.py
@@ -266,7 +266,7 @@ def update_enrollment(
     enrollment = _data_api().update_course_enrollment(username, course_id, mode=mode, is_active=is_active)
     if enrollment is None:
         msg = u"Course Enrollment not found for user {user} in course {course}".format(user=username, course=course_id)
-        log.warn(msg)
+        log.warning(msg)
         raise errors.EnrollmentNotFoundError(msg)
     else:
         if enrollment_attributes is not None:
@@ -455,7 +455,7 @@ def validate_course_mode(course_id, mode, is_active=None, include_expired=False)
             course_id=course_id,
             available=", ".join(available_modes)
         )
-        log.warn(msg)
+        log.warning(msg)
         raise errors.CourseModeNotFoundError(msg, course_enrollment_info)
 
 

--- a/openedx/core/djangoapps/enrollments/data.py
+++ b/openedx/core/djangoapps/enrollments/data.py
@@ -143,7 +143,7 @@ def create_course_enrollment(username, course_id, mode, is_active):
         user = User.objects.get(username=username)
     except User.DoesNotExist:
         msg = u"Not user with username '{username}' found.".format(username=username)
-        log.warn(msg)
+        log.warning(msg)
         raise UserNotFoundError(msg)
 
     try:
@@ -181,7 +181,7 @@ def update_course_enrollment(username, course_id, mode=None, is_active=None):
         user = User.objects.get(username=username)
     except User.DoesNotExist:
         msg = u"Not user with username '{username}' found.".format(username=username)
-        log.warn(msg)
+        log.warning(msg)
         raise UserNotFoundError(msg)
 
     try:
@@ -272,7 +272,7 @@ def _get_user(username):
         return User.objects.get(username=username)
     except User.DoesNotExist:
         msg = u"Not user with username '{username}' found.".format(username=username)
-        log.warn(msg)
+        log.warning(msg)
         raise UserNotFoundError(msg)
 
 
@@ -295,17 +295,17 @@ def _invalid_attribute(attributes):
     for attribute in attributes:
         if "namespace" not in attribute:
             msg = u"'namespace' not in enrollment attribute"
-            log.warn(msg)
+            log.warning(msg)
             invalid_attributes.append("namespace")
             raise InvalidEnrollmentAttribute(msg)
         if "name" not in attribute:
             msg = u"'name' not in enrollment attribute"
-            log.warn(msg)
+            log.warning(msg)
             invalid_attributes.append("name")
             raise InvalidEnrollmentAttribute(msg)
         if "value" not in attribute:
             msg = u"'value' not in enrollment attribute"
-            log.warn(msg)
+            log.warning(msg)
             invalid_attributes.append("value")
             raise InvalidEnrollmentAttribute(msg)
 


### PR DESCRIPTION
@felipemontoya, @amalbas, @mariajgrimaldi I made the following changes:

* log.warn was replaced by log.warning. log.warn is deprecated, see deprecation report: https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/

* Files affected in openedx/core/djangoapps/enrollments/: api.py and data.py

These tests passed:
openedx/core/djangoapps/enrollments/tests/test_api.py
openedx/core/djangoapps/enrollments/tests/test_data.py

Logging module deprecation note: https://docs.python.org/3/library/logging.html#logging.Logger.warning