### PR TITLE
Fix DeprecationWarning: Please use assertNotRegex instead

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_item.py
+++ b/cms/djangoapps/contentstore/views/tests/test_item.py
@@ -208,7 +208,7 @@ class GetItemTest(ItemTest):
         # XBlock messages are added by the Studio wrapper.
         self.assertIn('wrapper-xblock-message', html)
         # Make sure that "wrapper-xblock" does not appear by itself (without -message at end).
-        self.assertNotRegexpMatches(html, r'wrapper-xblock[^-]+')
+        self.assertNotRegex(html, r'wrapper-xblock[^-]+')
 
         # Verify that the header and article tags are still added
         self.assertIn('<header class="xblock-header xblock-header-vertical">', html)

--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -70,13 +70,13 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         self.assertRegex(html, r"data-block-type=[\"\']test_aside[\"\']")
         self.assertRegex(html, "Aside rendered")
         # Now ensure the acid_aside is not in the result
-        self.assertNotRegexpMatches(html, r"data-block-type=[\"\']acid_aside[\"\']")
+        self.assertNotRegex(html, r"data-block-type=[\"\']acid_aside[\"\']")
 
         # Ensure about pages don't have asides
         about = modulestore().get_item(course.id.make_usage_key('about', 'overview'))
         html = get_preview_fragment(request, about, context).content
-        self.assertNotRegexpMatches(html, r"data-block-type=[\"\']test_aside[\"\']")
-        self.assertNotRegexpMatches(html, "Aside rendered")
+        self.assertNotRegex(html, r"data-block-type=[\"\']test_aside[\"\']")
+        self.assertNotRegex(html, "Aside rendered")
 
     @XBlockAside.register_temp_plugin(AsideTestType, 'test_aside')
     def test_preview_no_asides(self):
@@ -106,8 +106,8 @@ class GetPreviewHtmlTestCase(ModuleStoreTestCase):
         }
         html = get_preview_fragment(request, html, context).content
 
-        self.assertNotRegexpMatches(html, r"data-block-type=[\"\']test_aside[\"\']")
-        self.assertNotRegexpMatches(html, "Aside rendered")
+        self.assertNotRegex(html, r"data-block-type=[\"\']test_aside[\"\']")
+        self.assertNotRegex(html, "Aside rendered")
 
     @mock.patch('xmodule.conditional_module.ConditionalModule.is_condition_satisfied')
     def test_preview_conditional_module_children_context(self, mock_is_condition_satisfied):

--- a/lms/djangoapps/commerce/tests/test_views.py
+++ b/lms/djangoapps/commerce/tests/test_views.py
@@ -130,7 +130,7 @@ class ReceiptViewTests(UserMixin, ModuleStoreTestCase):
             response.content.decode('utf-8'),
             user_message if is_user_message_expected else system_message
         )
-        self.assertNotRegexpMatches(
+        self.assertNotRegex(
             response.content.decode('utf-8'),
             user_message if not is_user_message_expected else system_message
         )

--- a/lms/djangoapps/dashboard/tests/test_sysadmin.py
+++ b/lms/djangoapps/dashboard/tests/test_sysadmin.py
@@ -193,7 +193,7 @@ class TestSysAdminMongoCourseImport(SysadminBaseTestCase):
 
         # Make sure we don't have any git hashes on the page
         response = self.client.get(reverse('sysadmin_courses'))
-        self.assertNotRegexpMatches(response.content.decode('utf-8'), table_re)
+        self.assertNotRegex(response.content.decode('utf-8'), table_re)
 
         # Now add the course and make sure it does match
         response = self._add_edx4edx()


### PR DESCRIPTION
This PR contributes to the elimination of deprecation warnings, specifically the one mentioned above and reported in [warnings report] (https://build.testeng.edx.org/job/edx-platform-python-pipeline-master/warning_5freport_5fall_2ehtml/). 
Changed assertNotRegexpMatches to assertNotRegex in the following files:

-  cms/djangoapps/contentstore/views/tests/test_preview.py

- cms/djangoapps/contentstore/views/tests/test_item.py

- lms/djangoapps/commerce/tests/test_views.py

- lms/djangoapps/dashboard/tests/test_sysadmin.py

This warning occurs due to deprecation in python 3.5: [Python 3.5 Test Case: assertNotRegex](https://docs.python.org/3.5/library/unittest.html#unittest.TestCase.assertNotRegex )

@felipemontoya 
@luismorenolopera 