### PR TITLE
Fixing render_to_response deprecated in Django 3 (openedx)

### DIFF
--- a/openedx/features/learner_profile/views/learner_profile.py
+++ b/openedx/features/learner_profile/views/learner_profile.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import Http404
-from django.shortcuts import redirect, render_to_response
+from django.shortcuts import redirect, render
 from django.urls import reverse
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_http_methods
@@ -51,9 +51,10 @@ def learner_profile(request, username):
 
     try:
         context = learner_profile_context(request, username, request.user.is_staff)
-        return render_to_response(
-            'learner_profile/learner_profile.html',
-            context
+        return render(
+            request=request,
+            template_name='learner_profile/learner_profile.html',
+            context=context
         )
     except (UserNotAuthorized, UserNotFound, ObjectDoesNotExist):
         raise Http404


### PR DESCRIPTION
Fixing RemovedInDjango30Warnings, on openedx, in commit #24073

**Background:** The `django.shortcuts` method `render_to_response` became deprecated in [Django 1.3](https://docs.djangoproject.com/en/3.0/releases/1.3/), when  `render` was introduced.

Per the documentation:

> render() is the same as a call to render_to_response() with a context_instance argument that forces the use of a RequestContext.

Both return an `HttpResponse` object.

**Context:** We changed two statements: An import line and the call to the method, adding explicit parameter names to improve readability.

**Before:**
```
from django.shortcuts import redirect, render_to_response
...
return render_to_response(
            'learner_profile/learner_profile.html',
            context
)

$ pytest openedx/features/learner_profile
=== 18 passed, 42 warnings in 94.32s ===

```

**After**
```
from django.shortcuts import redirect, render
...
return render(
            request=request,
            template_name='learner_profile/learner_profile.html',
            context=context
)

$ pytest openedx/features/learner_profile
=== 18 passed, 27 warnings in 46.22s ===
```

@felipemontoya 
@Alec4r 