### PR TITLE
Fixing render_to_response deprecated in Django 3 (lms)

### DIFF
--- a/lms/djangoapps/teams/views.py
+++ b/lms/djangoapps/teams/views.py
@@ -13,7 +13,7 @@ from django.core.exceptions import PermissionDenied
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.http import Http404, HttpResponse, JsonResponse
-from django.shortcuts import get_object_or_404, render_to_response
+from django.shortcuts import get_object_or_404, render
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_noop
@@ -210,7 +210,11 @@ class TeamsDashboardView(GenericAPIView):
             "disable_courseware_js": True,
             "teams_base_url": reverse('teams_dashboard', request=request, kwargs={'course_id': course_id}),
         }
-        return render_to_response("teams/teams.html", context)
+        return render(
+            request=request,
+            template_name="teams/teams.html",
+            context=context
+        )
 
     def _serialize_and_paginate(self, pagination_cls, queryset, request, serializer_cls, serializer_ctx):
         """


### PR DESCRIPTION
**Note:** This is basically the same as [this one](https://github.com/eduNEXT/edx-platform/pull/185)

Fixing RemovedInDjango30Warnings, on lms, in commit #24073

**Background:** The `django.shortcuts` method `render_to_response` became deprecated in [Django 1.3](https://docs.djangoproject.com/en/3.0/releases/1.3/), when  `render` was introduced.

Per the documentation:

> render() is the same as a call to render_to_response() with a context_instance argument that forces the use of a RequestContext.

Both return an `HttpResponse` object.

**Context:** We changed two statements: An import line and the call to the method, adding explicit parameter names to improve readability.

**Before:**
```
from django.shortcuts import get_object_or_404, render_to_response
...
return render_to_response("teams/teams.html", context)

$ pytest lms/djangoapps/teams/
=== 501 passed, 1 skipped, 656 warnings in 166.54s (0:02:46) ==

```

**After**
```
from django.shortcuts import get_object_or_404, render
...
return render(
            request=request,
            template_name="teams/teams.html",
            context=context
        )

$ pytest lms/djangoapps/teams/
=== 501 passed, 1 skipped, 649 warnings in 76.27s (0:01:16) ==
```

@felipemontoya 
@Alec4r 