### PR TITLE
Fixing implicit parser name for Beautiful Soup (lms, openedx)

### DIFF
--- a/lms/djangoapps/verify_student/tests/test_views.py
+++ b/lms/djangoapps/verify_student/tests/test_views.py
@@ -1000,7 +1000,7 @@ class TestPayAndVerifyView(UrlResetMixin, ModuleStoreTestCase, XssTestMixin, Tes
 
     def _get_page_data(self, response):
         """Retrieve the data attributes rendered on the page. """
-        soup = BeautifulSoup(response.content)
+        soup = BeautifulSoup(markup=response.content, features="lxml")
         pay_and_verify_div = soup.find(id="pay-and-verify-container")
 
         self.assertIsNot(

--- a/openedx/tests/xblock_integration/xblock_testcase.py
+++ b/openedx/tests/xblock_integration/xblock_testcase.py
@@ -449,7 +449,7 @@ class XBlockTestCase(XBlockStudentTestCaseMixin,
         '''
         usage_id = self.xblocks[urlname].scope_ids.usage_id
         # First, we get out our <div>
-        soup_html = BeautifulSoup(content)
+        soup_html = BeautifulSoup(markup=content, features="lxml")
         xblock_html = six.text_type(soup_html.find(id="seq_contents_0"))
         # Now, we get out the text of the <div>
         try:


### PR DESCRIPTION
_Note: This is a correction of PR edx#24100_

Fixing 56 GuessedAtParserWarnings, in commit edx#24117.

**Background**: BeautifulSoup automatically picks the fastest parser available. By default, it picks the "lxml" parser.

Per the [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/#installing-a-parser) documentation:

> Beautiful Soup supports the HTML parser included in Python’s standard library, but it also supports a number of third-party Python parsers. One is the lxml parser. Depending on your setup, you might install lxml with one of these commands.
> Another alternative is the pure-Python html5lib parser, which parses HTML the way a web browser does. 

**Context**: We changed two statements, one in lms and another in openedx. Both statements fire up BeautifulSoup. Now we explicitly ask for "lxml," following the recommendation on BeautifulSoup's documentation:
> If you can, I recommend you install and use lxml for speed. If you’re using a very old version of Python – earlier than 2.7.3 or 3.2.2 – it’s essential that you install lxml or html5lib. Python’s built-in HTML parser is just not very good in those old versions.

**Before**:
`soup = BeautifulSoup(content)`

**After**:
`soup = BeautifulSoup(markup=content, features="lxml")`

The warnings are gone, tests are passing in local.

@felipemontoya
@Alec4r