### PR TITLE
Updating django-ses version

### DIFF
--- a/requirements/edx/base.in
+++ b/requirements/edx/base.in
@@ -57,7 +57,7 @@ django-ratelimit-backend==1.1.1
 django-require
 django-rest-swagger                 # API documentation
 django-sekizai
-django-ses==0.8.4
+django-ses==1.0.3
 django-simple-history
 django-splash
 django-statici18n==1.4.0

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -96,7 +96,7 @@ django-ratelimit==1.1.0
 django-require==1.0.11
 django-rest-swagger==2.2.0
 django-sekizai==0.10.0
-django-ses==0.8.4
+django-ses==1.0.3
 django-simple-history==2.1.1
 django-splash==0.2.2
 django-statici18n==1.4.0
@@ -138,7 +138,7 @@ feedparser==5.1.3
 firebase-token-generator==1.3.2
 fs-s3fs==0.1.8
 fs==2.0.18
-future==0.16.0            # via pyjwkest
+future==0.16.0            # via django-ses, pyjwkest
 futures==3.2.0 ; python_version == "2.7"
 glob2==0.3
 gunicorn==0.17.4


### PR DESCRIPTION
As of Feb 28, AWS deprecated support for Signature Version 3, only Signature Version 4 is available for their SES service.

Support for signature version 4 comes with boto3 but the version of django-ses installed in the LLPA was 0.8.4 which only uses boto.

django-ses started using boto3 from version 1.0.0 https://github.com/django-ses/django-ses/pull/183 so we needed to update to that a version greater or equal to 1.0.0

1.0.3 is the latest version of django-ses available in py-pi and it still has support for python 2.7 and django 1.11, it also uses boto3 to send the emails which ensures the requests are signed with signature version 4.

Since the LLPA doesn't have a stage, this was deployed in prod already and is working correctly.

Ticket #13886

