### PR TITLE
JU/UT002

### DIFF
--- a/common/djangoapps/student/models.py
+++ b/common/djangoapps/student/models.py
@@ -464,7 +464,7 @@ class UserProfile(models.Model):
 
     # Optional demographic data we started capturing from Fall 2012
     this_year = datetime.now(UTC).year
-    VALID_YEARS = list(range(this_year, this_year - 120, -1))
+    VALID_YEARS = range(this_year - 16, this_year - 120, -1)
     year_of_birth = models.IntegerField(blank=True, null=True, db_index=True)
     GENDER_CHOICES = (
         (u'm', ugettext_noop(u'Male')),

--- a/lms/static/js/spec/student_account/account_settings_factory_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_factory_spec.js
@@ -111,7 +111,7 @@ define(['backbone',
 
                 var sectionsData = accountSettingsView.options.tabSections.aboutTabSections;
 
-                expect(sectionsData[0].fields.length).toBe(7);
+                expect(sectionsData[0].fields.length).toBe(6);
 
                 var textFields = [sectionsData[0].fields[1], sectionsData[0].fields[2]];
                 for (i = 0; i < textFields.length; i++) {
@@ -183,10 +183,9 @@ define(['backbone',
                 USERNAME: 0,
                 FULL_NAME: 1,
                 EMAIL_ADDRESS: 2,
-                PASSWORD: 3,
-                LANGUAGE: 4,
-                COUNTRY: 5,
-                TIMEZONE: 6
+                LANGUAGE: 3,
+                COUNTRY: 4,
+                TIMEZONE: 5
             };
             var additionalInfoFields = {
                 EDUCATION: 0,
@@ -274,7 +273,7 @@ define(['backbone',
 
                 sectionsData = accountSettingsView.options.tabSections.aboutTabSections;
 
-                expect(sectionsData[accountInfoTab.BASIC_ACCOUNT_INFORMATION].fields.length).toBe(7);
+                expect(sectionsData[accountInfoTab.BASIC_ACCOUNT_INFORMATION].fields.length).toBe(6);
 
                 // Verify that username, name and email fields are readonly
                 textFields = [

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -156,19 +156,20 @@
                         },
                         fullnameFieldView,
                         emailFieldView,
-                        {
-                            view: new AccountSettingsFieldViews.PasswordFieldView({
-                                model: userAccountModel,
-                                title: gettext('Password'),
-                                screenReaderTitle: gettext('Reset Your Password'),
-                                valueAttribute: 'password',
-                                emailAttribute: 'email',
-                                passwordResetSupportUrl: passwordResetSupportUrl,
-                                linkTitle: gettext('Reset Your Password'),
-                                linkHref: fieldsData.password.url,
-                                helpMessage: gettext('Check your email account for instructions to reset your password.')  // eslint-disable-line max-len
-                            })
-                        },
+                        // {
+                        //     view: new AccountSettingsFieldViews.PasswordFieldView({
+                        //         model: userAccountModel,
+                        //         title: gettext('Password'),
+                        //         screenReaderTitle: gettext('Reset Your Password'),
+                        //         valueAttribute: 'password',
+                        //         emailAttribute: 'email',
+                        //         passwordResetSupportUrl: passwordResetSupportUrl,
+                        //         linkTitle: gettext('Reset Your Password'),
+                        //         linkHref: fieldsData.password.url,
+                        //         eslint-disable-next-line max-len
+                        //         helpMessage: gettext('Check your email account for instructions to reset your password.')
+                        //     })
+                        // },
                         {
                             view: new AccountSettingsFieldViews.LanguagePreferenceFieldView({
                                 model: userPreferencesModel,

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -37,14 +37,14 @@
                         selected: true,
                         expanded: true
                     },
-                    {
-                        name: 'accountsTabSections',
-                        id: 'accounts-tab',
-                        label: gettext('Linked Accounts'),
-                        tabindex: -1,
-                        selected: false,
-                        expanded: false
-                    }
+                    // {
+                    //     name: 'accountsTabSections',
+                    //     id: 'accounts-tab',
+                    //     label: gettext('Linked Accounts'),
+                    //     tabindex: -1,
+                    //     selected: false,
+                    //     expanded: false
+                    // }
                 ];
                 if (!view.options.disableOrderHistoryTab) {
                     accountSettingsTabs.push({

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -111,11 +111,11 @@ def account_settings_context(request):
         'nav_hidden': True,
         'fields': {
             'country': {
-                'options': list(countries),
+                'options': [(u'UY', u'Uruguay')],  # For all options use list(countries)
             }, 'gender': {
                 'options': [(choice[0], _(choice[1])) for choice in UserProfile.GENDER_CHOICES],
             }, 'language': {
-                'options': released_languages(),
+                'options': [(u'es-419', u'Español (Latinoamérica)')],  # For all options use released_languages(),
             }, 'level_of_education': {
                 'options': [(choice[0], _(choice[1])) for choice in UserProfile.LEVEL_OF_EDUCATION_CHOICES],
             }, 'password': {
@@ -123,7 +123,7 @@ def account_settings_context(request):
             }, 'year_of_birth': {
                 'options': year_of_birth_options,
             }, 'preferred_language': {
-                'options': all_languages(),
+                'options': [(u'es-419', u'Español (Latinoamérica)')],  # For all options use all_languages()
             }, 'time_zone': {
                 'options': TIME_ZONE_CHOICES,
             }

--- a/openedx/core/djangoapps/user_authn/views/tests/test_register.py
+++ b/openedx/core/djangoapps/user_authn/views/tests/test_register.py
@@ -780,7 +780,7 @@ class RegistrationViewTest(ThirdPartyAuthTestMixin, UserAPITestCase):
                     "name": six.text_type(year),
                     "default": False
                 }
-                for year in range(this_year, this_year - 120, -1)
+                for year in range(this_year - 16, this_year - 120, -1)
             ]
         )
         self._assert_reg_field(


### PR DESCRIPTION
## Description
 Modify the student account page.

## Testing instructions

Log in the LMS platform with a user. Go to the account settings page in /account/settings. Then, check the following:

1. The tab "linked accounts" ("Cuentas asociadas") is not present.
2. The Password is not editable in this form.
3. The earliest birth year in the dropdown menu should be the value `current_year - 16`, (example for 2017 the value is `2017-16 = 2001`)
4. The country select field should have only one option: Uruguay.
5. The preferred language select should have only one option: "Spanish" ("Español (latinoamérica)")

**Previous version commit:** b0ed5f4012
