### PR TITLE
Utec lowest passing grade fix & cookie consent message 

### DIFF
--- a/lms/templates/widgets/cookie-consent.html
+++ b/lms/templates/widgets/cookie-consent.html
@@ -17,7 +17,7 @@ window.addEventListener("load", function(){
       button: {background: "#005379", text: "#ffffff"},
     },
     "content": {
-      "message": "${_('This website uses cookies to ensure you get the best experience on our website. If you continue browsing this site, we understand that you accept the use of cookies.')}",
+      "message": "${_('Utilizamos cookies para optimizar el uso de la Plataforma, siendo algunas de ellas necesarias para que la misma cumpla con sus funcionalidades. Si continúas haciendo uso de la Plataforma, consideraremos que aceptas las cookies empleadas. Puedes obtener más información leyendo nuestra Política de Cookies')}",
       "dismiss": "${_('Got it!')}",
       "link": "${_('Learn more')}",
     },

--- a/openedx/core/djangoapps/content/course_overviews/models.py
+++ b/openedx/core/djangoapps/content/course_overviews/models.py
@@ -372,6 +372,12 @@ class CourseOverview(TimeStampedModel):
         return self._location
 
     @property
+    def utec_lowest_passing_grade(self):
+        store = modulestore()
+        descriptor = store.get_course(self.id)
+        return descriptor.utec_lowest_passing_grade
+    
+    @property
     def number(self):
         """
         Returns this course's number.


### PR DESCRIPTION
## Description
- The porperty **utec_lowest_passing_grade** was added to the **CourseOverview** class to fix the cases in which the user did not meet the minimum grade to obtain a certificate

- The cookie consent message was changed

## Testing instructions
- Earn a certificate. The dashboard should have a message saying 'Tu nota final es: 5' (grades go from 1 to 5)
- The certificate should have the text: 'La calificacion de aprobacion es 5'
- If the grade is below the minimum passing grade the text on the dashboard should say: ' Se requiere una calificación para obtener un `{cert_name}`: 2 '

**Previous version commit:** 4c8047c90c8aa642585115e797d0dc1b5b1bb27d