### PR TITLE
Increase randomization bins for python problems

### DIFF
--- a/common/lib/xmodule/xmodule/capa_base.py
+++ b/common/lib/xmodule/xmodule/capa_base.py
@@ -40,7 +40,7 @@ log = logging.getLogger("edx.courseware")
 _ = lambda text: text
 
 # Generate this many different variants of problems with rerandomize=per_student
-NUM_RANDOMIZATION_BINS = 20
+NUM_RANDOMIZATION_BINS = 200
 # Never produce more than this many different seeds, no matter what.
 MAX_RANDOMIZATION_BINS = 1000
 


### PR DESCRIPTION
## Description

We want to increase the number of randomization options for python problems. There's a limit of 20 seeds when using the `per_student` option, meaning that for a large number of students the problems are bound to repeat themselves.