### PR TITLE
feat: add first version of the certificate change event

### DIFF
--- a/lms/djangoapps/certificates/models.py
+++ b/lms/djangoapps/certificates/models.py
@@ -22,7 +22,7 @@ from model_utils import Choices
 from model_utils.fields import AutoCreatedField
 from model_utils.models import TimeStampedModel
 from openedx_events.learning.data import CertificateData, StudentData, CourseOverviewData, UserProfileData
-from openedx_events.learning.signals import CERTIFICATE_CREATED
+from openedx_events.learning.signals import CERTIFICATE_CREATED, CERTIFICATE_CHANGED
 from opaque_keys.edx.django.models import CourseKeyField
 from simple_history.models import HistoricalRecords
 
@@ -425,12 +425,28 @@ class GeneratedCertificate(models.Model):
         Credentials IDA.
         """
         super().save(*args, **kwargs)
-        COURSE_CERT_CHANGED.send_robust(
-            sender=self.__class__,
-            user=self.user,
-            course_key=self.course_id,
-            mode=self.mode,
-            status=self.status,
+        CERTIFICATE_CHANGED.send_event(
+                certificate=CertificateData(
+                    user=StudentData(
+                        username=self.user.username,
+                        email=self.user.email,
+                        first_name=self.user.first_name,
+                        last_name=self.user.last_name,
+                        is_active=self.user.is_active,
+                        profile=UserProfileData(
+                            meta=self.user.profile.meta,
+                            name=self.user.profile.name,
+                        )
+                    ),
+                    course=CourseOverviewData(
+                        course_key=self.course_id,
+                    ),
+                    mode=self.mode,
+                    grade=self.grade,
+                    status=self.status,
+                    download_url=self.download_url,
+                    name=self.name
+                )
         )
         if CertificateStatuses.is_passing_status(self.status):
             CERTIFICATE_CREATED.send_event(

--- a/lms/djangoapps/certificates/tests/test_models.py
+++ b/lms/djangoapps/certificates/tests/test_models.py
@@ -574,3 +574,47 @@ class EnrollmentEventsTest(SharedModuleStoreTestCase):
                 name='Certificate'
             )
         )
+
+    @patch("lms.djangoapps.certificates.models.CERTIFICATE_CHANGED")
+    def test_certificate_changed_event_emitted(self, certificate_changed_event):
+        """
+        Test whether the certificate changed event is sent during the certificate
+        modification process.
+
+        Expected result:
+            - CERTIFICATE_CHANGED is sent via send_event.
+            - The arguments match the event definition.
+        """
+        GeneratedCertificateFactory.create(
+            status=CertificateStatuses.notpassing,
+            user=self.user,
+            course_id=self.course.id,
+            mode=GeneratedCertificate.MODES.honor,
+            name='Certificate',
+            grade='100',
+            download_url='https://certificate.pdf'
+        )
+
+        certificate_changed_event.send_event.assert_called_once_with(
+            certificate=CertificateData(
+                user=StudentData(
+                    username=self.user.username,
+                    email=self.user.email,
+                    first_name=self.user.first_name,
+                    last_name=self.user.last_name,
+                    is_active=self.user.is_active,
+                    profile=UserProfileData(
+                        meta=self.user.profile.meta,
+                        name=self.user.profile.name,
+                    )
+                ),
+                course=CourseOverviewData(
+                    course_key=self.course.id,
+                ),
+                mode=GeneratedCertificate.MODES.honor,
+                grade='100',
+                status=CertificateStatuses.notpassing,
+                download_url='https://certificate.pdf',
+                name='Certificate'
+            )
+        )


### PR DESCRIPTION
<!--
##
####         Note: the Lilac master branch has been created.  Please consider whether your change
    ####     should also be applied to Lilac.  If so, make another pull request against the
####         open-release/lilac.master branch, or ping @nedbat for help or questions.
##

Please give the pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply. You may link to information rather than copy it.
More details about the template are at https://github.com/edx/open-edx-proposals/pull/180
(link will be updated when that document merges)
-->

## Description

Describe what this pull request changes, and why. Include implications for people using this change.
Design decisions and their rationales should be documented in the repo (docstring / ADR), per
[OEP-19](https://open-edx-proposals.readthedocs.io/en/latest/oep-0019-bp-developer-documentation.html), and can be
linked here.

Useful information to include:
- Which edX user roles will this change impact? Common user roles are "Learner", "Course Author",
"Developer", and "Operator".
- Include screenshots for changes to the UI (ideally, both "before" and "after" screenshots, if applicable).
- Provide links to the description of corresponding configuration changes. Remember to correctly annotate these
changes.

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
