### PR TITLE
test: add isolation mixin for openedx-events testing

### DIFF
--- a/common/djangoapps/student/tests/test_events.py
+++ b/common/djangoapps/student/tests/test_events.py
@@ -20,6 +20,7 @@ from openedx_events.learning.data import (
     UserData,
     UserPersonalData,
 )
+from openedx_events.tests.utils import OpenEdxEventsTestCase
 from openedx.core.djangolib.testing.utils import skip_unless_lms
 
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase

--- a/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
+++ b/common/lib/xmodule/xmodule/modulestore/tests/django_utils.py
@@ -28,6 +28,7 @@ from xmodule.modulestore.django import SignalHandler, clear_existing_modulestore
 from xmodule.modulestore.tests.factories import XMODULE_FACTORY_LOCK
 from xmodule.modulestore.tests.mongo_connection import MONGO_HOST, MONGO_PORT_NUM
 
+from openedx_events.tests.utils import OpenEdxEventsTestCase
 
 class CourseUserType(Enum):
     """
@@ -363,7 +364,11 @@ class ModuleStoreTestUsersMixin():
 
 
 class SharedModuleStoreTestCase(
-    ModuleStoreTestUsersMixin, FilteredQueryCountMixin, ModuleStoreIsolationMixin, CacheIsolationTestCase
+    ModuleStoreTestUsersMixin,
+    FilteredQueryCountMixin,
+    ModuleStoreIsolationMixin,
+    CacheIsolationTestCase,
+    OpenEdxEventsTestCase,
 ):
     """
     Subclass for any test case that uses a ModuleStore that can be shared

--- a/openedx/core/djangoapps/user_api/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/tests/test_views.py
@@ -11,6 +11,7 @@ from openedx.core.djangoapps.django_comment_common import models
 from openedx.core.djangolib.testing.utils import CacheIsolationTestCase, skip_unless_lms
 from openedx.core.lib.api.test_utils import TEST_API_KEY, ApiTestCase
 from openedx.core.lib.time_zone_utils import get_display_time_zone
+from openedx_events.tests.utils import OpenEdxEventsTestCase
 from common.djangoapps.student.tests.factories import UserFactory
 from xmodule.modulestore.tests.django_utils import SharedModuleStoreTestCase
 from xmodule.modulestore.tests.factories import CourseFactory
@@ -28,7 +29,7 @@ USER_PREFERENCE_LIST_URI = "/api/user/v1/user_prefs/"
 ROLE_LIST_URI = "/api/user/v1/forum_roles/Moderator/users/"
 
 
-class UserAPITestCase(ApiTestCase):
+class UserAPITestCase(ApiTestCase, OpenEdxEventsTestCase):
     """
     Parent test case for User API workflow coverage
     """

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -687,7 +687,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.in
-openedx-events==0.4.1
+git+https://github.com/eduNEXT/openedx-events@MJG/isolate_signal_sending#egg=openedx-events==0.5.0_alpha
     # via -r requirements/edx/base.in
 ora2==3.6.18
     # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -896,7 +896,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/testing.txt
-openedx-events==0.4.1
+git+https://github.com/eduNEXT/openedx-events@MJG/isolate_signal_sending#egg=openedx-events==0.5.0_alpha
     # via -r requirements/edx/testing.txt
 ora2==3.6.18
     # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -850,7 +850,7 @@ oauthlib==3.0.1
     #   social-auth-core
 openedx-calc==2.0.1
     # via -r requirements/edx/base.txt
-openedx-events==0.4.1
+git+https://github.com/eduNEXT/openedx-events@MJG/isolate_signal_sending#egg=openedx-events==0.5.0_alpha
     # via -r requirements/edx/base.txt
 ora2==3.6.18
     # via -r requirements/edx/base.txt


### PR DESCRIPTION
This PR uses what's implemented in: https://github.com/eduNEXT/openedx-events/blob/MJG/isolate_signal_sending/openedx_events/tests/utils.py