### PR TITLE
fix: disable whitelist in the restricted email verification

### DIFF
--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -256,7 +256,7 @@ class AccountCreationForm(forms.Form):
                 # This email is not on the whitelist of allowed emails. Check if
                 # they may have been manually invited by an instructor and if not,
                 # reject the registration.
-                if not CourseEnrollmentAllowed.objects.filter(email=email).exists() and not 'social_auth_provider' in self.data:
+                if not 'social_auth_provider' in self.data:
                     raise ValidationError(_(
                         u"Unauthorized email, If you are a Técnico user (student, professor or staff) please register via Técnico-ID"
                     ))


### PR DESCRIPTION
Currently users with tecnico.ulisboa.pt  domain email must be forced to log in by Tecnico-ID but when a user that does not exist in the platform is enrolled from the instructor panel (is added to the whitelist) then the user can bypass this restriction and register directly without using Tecnico-ID, so now only those who login via Tecnico-ID will be able to register with a restricted email