### PR TITLE
JU/CAMROM-007: Custom registration fields

### DIFF
--- a/lms/static/js/spec/student_account/account_settings_factory_spec.js
+++ b/lms/static/js/spec/student_account/account_settings_factory_spec.js
@@ -132,7 +132,7 @@ define(['backbone',
                 var dropdownFields = [
                     sectionsData[1].fields[0],
                     sectionsData[1].fields[1],
-                    sectionsData[1].fields[2]
+                    sectionsData[1].fields[3]
                 ];
                 _.each(dropdownFields, function(field) {
                     var view = field.view;
@@ -191,8 +191,8 @@ define(['backbone',
             var additionalInfoFields = {
                 EDUCATION: 0,
                 GENDER: 1,
-                YEAR_OF_BIRTH: 2,
-                PREFERRED_LANGUAGE: 3
+                YEAR_OF_BIRTH: 3,
+                PREFERRED_LANGUAGE: 2
             };
 
             beforeEach(function() {

--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -225,20 +225,20 @@
                             })
                         },
                         {
-                            view: new AccountSettingsFieldViews.DropdownFieldView({
-                                model: userAccountModel,
-                                title: gettext('Year of Birth'),
-                                valueAttribute: 'year_of_birth',
-                                options: fieldsData.year_of_birth.options,
-                                persistChanges: true
-                            })
-                        },
-                        {
                             view: new AccountSettingsFieldViews.LanguageProficienciesFieldView({
                                 model: userAccountModel,
                                 title: gettext('Preferred Language'),
                                 valueAttribute: 'language_proficiencies',
                                 options: fieldsData.preferred_language.options,
+                                persistChanges: true
+                            })
+                        },
+                        {
+                            view: new AccountSettingsFieldViews.DropdownFieldView({
+                                model: userAccountModel,
+                                title: gettext('Year of Birth'),
+                                valueAttribute: 'year_of_birth',
+                                options: fieldsData.year_of_birth.options,
                                 persistChanges: true
                             })
                         }

--- a/openedx/core/djangoapps/user_api/accounts/api.py
+++ b/openedx/core/djangoapps/user_api/accounts/api.py
@@ -37,6 +37,8 @@ from openedx.core.djangoapps.user_authn.views.registration_form import validate_
 from openedx.core.lib.api.view_utils import add_serializer_errors
 from openedx.features.enterprise_support.utils import get_enterprise_readonly_account_fields
 from .serializers import AccountLegacyProfileSerializer, AccountUserSerializer, UserReadOnlySerializer, _visible_fields
+from campusromero_openedx_extensions.custom_registration_form.context_extender import partial_update_account
+
 
 # Public access point for this function.
 visible_fields = _visible_fields
@@ -159,6 +161,8 @@ def update_account_settings(requesting_user, update, username=None):
         _store_old_name_if_needed(old_name, user_profile, requesting_user)
         _update_extended_profile_if_needed(update, user_profile)
         _update_state_if_needed(update, user_profile)
+
+        partial_update_account(update, user)
 
     except PreferenceValidationError as err:
         raise AccountValidationError(err.preference_errors)

--- a/openedx/core/djangoapps/user_api/accounts/serializers.py
+++ b/openedx/core/djangoapps/user_api/accounts/serializers.py
@@ -33,6 +33,7 @@ from . import (
 )
 from .image_helpers import get_profile_image_urls_for_user
 from .utils import format_social_link, validate_social_link
+from campusromero_openedx_extensions.custom_registration_form.context_extender import update_account_serializer
 
 PROFILE_IMAGE_KEY_PREFIX = 'image_url'
 LOGGER = logging.getLogger(__name__)
@@ -192,6 +193,7 @@ class UserReadOnlySerializer(serializers.Serializer):
                 }
             )
 
+        update_account_serializer(data, user)
         if self.custom_fields:
             fields = self.custom_fields
         elif user_profile:

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -36,6 +36,8 @@ from student.models import UserProfile
 from third_party_auth import pipeline
 from util.date_utils import strftime_localized
 
+from campusromero_openedx_extensions.custom_registration_form.context_extender import update_account_view
+
 log = logging.getLogger(__name__)
 
 
@@ -176,6 +178,7 @@ def account_settings_context(request):
             # in with, or if the user is already authenticated with them.
         } for state in auth_states if state.provider.display_for_login or state.has_account]
 
+    update_account_view(context, user)
     return context
 
 

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_api.py
@@ -550,7 +550,14 @@ class AccountSettingsOnCreationTest(CreateAccountMixin, TestCase):
             'language_proficiencies': [],
             'account_privacy': PRIVATE_VISIBILITY,
             'accomplishments_shared': False,
-            'extended_profile': [],
+            'extended_profile': [
+                {'field_value': None, 'field_name': 'month_of_birth'},
+                {'field_value': None, 'field_name': 'day_of_birth'},
+                {'field_value': '', 'field_name': 'dni'},
+                {'field_value': None, 'field_name': 'phone_number'},
+                {'field_value': '', 'field_name': 'institution'},
+                {'field_value': None, 'field_name': 'province'}
+            ],
             'secondary_email': None,
             'secondary_email_enabled': None,
             'time_zone': None,

--- a/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/tests/test_views.py
@@ -358,7 +358,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(27):
             response = self.send_get(self.different_client)
         self._verify_full_shareable_account_response(response, account_privacy=ALL_USERS_VISIBILITY)
 
@@ -373,7 +373,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         """
         self.different_client.login(username=self.different_user.username, password=TEST_PASSWORD)
         self.create_mock_profile(self.user)
-        with self.assertNumQueries(23):
+        with self.assertNumQueries(27):
             response = self.send_get(self.different_client)
         self._verify_private_account_response(response)
 
@@ -518,12 +518,12 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
             self.assertEqual(False, data["accomplishments_shared"])
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        verify_get_own_information(21)
+        verify_get_own_information(25)
 
         # Now make sure that the user can get the same information, even if not active
         self.user.is_active = False
         self.user.save()
-        verify_get_own_information(13)
+        verify_get_own_information(14)
 
     def test_get_account_empty_string(self):
         """
@@ -538,7 +538,7 @@ class TestAccountsAPI(CacheIsolationTestCase, UserAPITestCase):
         legacy_profile.save()
 
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(25):
             response = self.send_get(self.client)
         for empty_field in ("level_of_education", "gender", "country", "state", "bio",):
             self.assertIsNone(response.data[empty_field])


### PR DESCRIPTION
## Description
Add new fields to the registration page. (This part is done through an extra app in the plugin). Includes the extra fields in the account settings page and the order of some fields is changed. Fix test accordingly.

## How to test
You should enable the Campus Romero theme.

Go to the registration page and two new fields should be present: _DNI_ and _Provincia_. _Provincia_ only appears if the selected country is _Perú_, otherwise it'll be hidden.

In the account setting page, in the additional information section, language preference and year of birth should be swapped and
 the following additional fields should appear:

- Month of birth
- Day of birth
- DNI
- Phone number
- Institution
- Language preference

## Extra info
The logic was moved to the plugin to make it more maintainable. https://github.com/eduNEXT/campusromero-openedx-extensions/pull/52

**Previous commits:**
[`cd2009a`](https://github.com/eduNEXT/edx-platform/pull/155/commits/cd2009a)
[`89c9c89`](https://github.com/eduNEXT/edx-platform/pull/155/commits/89c9c89)