### PR TITLE
Third party auth microsite aware

### DIFF
--- a/common/djangoapps/third_party_auth/__init__.py
+++ b/common/djangoapps/third_party_auth/__init__.py
@@ -14,5 +14,6 @@ def is_enabled():
 
     return configuration_helpers.get_value(
         "ENABLE_THIRD_PARTY_AUTH",
-        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH")
+        # This forces the module to be enabled on a per tenant basis
+        settings.FEATURES.get("ENABLE_THIRD_PARTY_AUTH_FOR_TEST", False)
     )

--- a/common/djangoapps/third_party_auth/models.py
+++ b/common/djangoapps/third_party_auth/models.py
@@ -348,7 +348,9 @@ class OAuth2ProviderConfig(ProviderConfig):
     # example:
     # class SecondOpenIDProvider(OpenIDAuth):
     #   name = "second-openId-provider"
-    KEY_FIELDS = ('backend_name',)
+    # eduNEXT: added site_id to KEY_FIELDS so we can have an active OAuth2ProviderConfig per site for each backend.
+    # This will change the calls to the method current, now it needs to be called passing site_id and backend_name.
+    KEY_FIELDS = ('site_id', 'backend_name')
     prefix = 'oa2'
     backend_name = models.CharField(
         max_length=50, blank=False, db_index=True,
@@ -376,6 +378,24 @@ class OAuth2ProviderConfig(ProviderConfig):
         app_label = "third_party_auth"
         verbose_name = u"Provider Configuration (OAuth)"
         verbose_name_plural = verbose_name
+        
+    @classmethod
+    def current(cls, *args):
+        """
+        Get the current config model for the provider according to the given backend and the current
+        site.
+        """
+        site_id = Site.objects.get_current(get_current_request()).id
+        return super(OAuth2ProviderConfig, cls).current(site_id, *args)
+
+    @property
+    def provider_id(self):
+        """
+        Unique string key identifying this provider. Must be URL and css class friendly.
+        eduNEXT: override method to cast site_id field.
+        """
+        assert self.prefix is not None
+        return "-".join((self.prefix, ) + tuple(str(getattr(self, field)) for field in self.KEY_FIELDS))
 
     def clean(self):
         """ Standardize and validate fields """


### PR DESCRIPTION
- Change KEY_FIELD from KEY_FIELDS = ('backend_name') to KEY_FIELDS = ('site_id', 'backend_name')
- Override provider_id to cast field
- Override current method to pass site_id