### PR TITLE
Prefill custom fields in the registration form with TPA data.

### DIFF
--- a/lms/envs/common.py
+++ b/lms/envs/common.py
@@ -3789,6 +3789,12 @@ FINANCIAL_ASSISTANCE_MAX_LENGTH = 2500
 
 REGISTRATION_EXTENSION_FORM = None
 
+# .. setting_name: REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES
+# .. setting_default: []
+# .. setting_description: List of custom fields included in the registriation
+#      form extension to be prefilled with third party auth data.
+REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES = []
+
 # Identifier included in the User Agent from open edX mobile apps.
 MOBILE_APP_USER_AGENT_REGEXES = [
     r'edX/org.edx.mobile',

--- a/openedx/core/djangoapps/user_authn/views/registration_form.py
+++ b/openedx/core/djangoapps/user_authn/views/registration_form.py
@@ -1078,7 +1078,7 @@ class RegistrationFormFactory(object):
                         ) or current_provider.sync_learner_profile_data
                     )
 
-                    for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS:
+                    for field_name in self.DEFAULT_FIELDS + self.EXTRA_FIELDS + settings.REGISTRATION_EXTENSION_FORM_FIELDS_TPA_OVERRIDES:
                         if field_name in field_overrides:
                             form_desc.override_field_properties(
                                 field_name, default=field_overrides[field_name]


### PR DESCRIPTION
## Description
Usually the method [`_apply_third_party_auth_overrides`](https://github.com/eduNEXT/edx-platform/blob/open-release/koa.nelp/openedx/core/djangoapps/user_authn/views/registration_form.py#L1044) auto completes the register form with data from the provider. The fields that are prefilled are defined in [`DEFAULT_FIELDS, EXTRA_FIELDS`](https://github.com/eduNEXT/edx-platform/blob/912ed6ac6cc5326960de90a4fa32900f522a24d9/openedx/core/djangoapps/user_authn/views/registration_form.py#L298-L319). If we use custom fields via a custom registration form, it's not possible to prefill the fields even if the provider send us all the data.

This PR adds a new setting to include additional fields to be prefilled.