### PR TITLE
Fix the theme compilation issue since juniper (#24990)

### DIFF
--- a/common/lib/xmodule/xmodule/static_content.py
+++ b/common/lib/xmodule/xmodule/static_content.py
@@ -94,20 +94,24 @@ def write_descriptor_js(output_root):
 
 def _list_descriptors():
     """Return a list of all registered XModuleDescriptor classes."""
-    return [
-        desc for desc in [
+    return sorted(
+        [
             desc for (_, desc) in XModuleDescriptor.load_classes()
-        ]
-    ] + XBLOCK_CLASSES
+        ] + XBLOCK_CLASSES,
+        key=str
+    )
 
 
 def _list_modules():
     """Return a list of all registered XModule classes."""
-    return [
-        desc.module_class for desc in [
-            desc for (_, desc) in XModuleDescriptor.load_classes()
-        ]
-    ] + XBLOCK_CLASSES
+    return sorted(
+        [
+            desc.module_class for desc in [
+                desc for (_, desc) in XModuleDescriptor.load_classes()
+            ]
+        ] + XBLOCK_CLASSES,
+        key=str
+    )
 
 
 def _ensure_dir(directory):
@@ -152,7 +156,8 @@ def _write_styles(selector, output_root, classes, css_attribute):
         "@import 'bourbon/bourbon';",
         "@import 'lms/theme/variables';",
     ]
-    for class_, fragment_names in css_imports.items():
+    for class_, fragment_names in sorted(css_imports.items()):
+        fragment_names = sorted(fragment_names)
         module_styles_lines.append("""{selector}.xmodule_{class_} {{""".format(
             class_=class_, selector=selector
         ))
@@ -268,7 +273,13 @@ def write_webpack(output_file, module_files, descriptor_files):
         outfile.write(
             textwrap.dedent(u"""\
                 module.exports = {config_json};
-            """).format(config_json=json.dumps(config, indent=4))
+            """).format(
+                config_json=json.dumps(
+                    config,
+                    indent=4,
+                    sort_keys=True,
+                )
+            )
         )
 
 

--- a/openedx/core/djangoapps/theming/storage.py
+++ b/openedx/core/djangoapps/theming/storage.py
@@ -10,7 +10,7 @@ import re
 
 from django.conf import settings
 from django.contrib.staticfiles.finders import find
-from django.contrib.staticfiles.storage import CachedFilesMixin, StaticFilesStorage
+from django.contrib.staticfiles.storage import ManifestFilesMixin, StaticFilesStorage
 from django.utils._os import safe_join
 from django.utils.six.moves.urllib.parse import (  # pylint: disable=no-name-in-module, import-error
     unquote,
@@ -110,10 +110,10 @@ class ThemeStorage(ThemeMixin, StaticFilesStorage):
     pass
 
 
-class ThemeCachedFilesMixin(CachedFilesMixin):
+class ThemeManifestFilesMixin(ManifestFilesMixin):
     """
-    Comprehensive theme aware CachedFilesMixin.
-    Main purpose of subclassing CachedFilesMixin is to override the following methods.
+    Comprehensive theme aware ManifestFilesMixin.
+    Main purpose of subclassing ManifestFilesMixin is to override the following methods.
     1 - _url
     2 - url_converter
 
@@ -177,11 +177,11 @@ class ThemeCachedFilesMixin(CachedFilesMixin):
         See the class docstring for more info.
         """
         processed_asset_name = self._processed_asset_name(name)
-        return super(ThemeCachedFilesMixin, self)._url(hashed_name_func, processed_asset_name, force, hashed_files)
+        return super()._url(hashed_name_func, processed_asset_name, force, hashed_files)
 
     def url_converter(self, name, hashed_files, template=None):
         """
-        This is an override of url_converter from CachedFilesMixin.
+        This is an override of url_converter from ManifestFilesMixin.
         It changes one line near the end of the method (see the NOTE) in order
         to return absolute urls instead of relative urls.  This behavior is
         necessary for theme overrides, as we get 404 on assets with relative

--- a/openedx/core/storage.py
+++ b/openedx/core/storage.py
@@ -12,7 +12,7 @@ from pipeline.storage import NonPackagingMixin
 from require.storage import OptimizedFilesMixin
 from storages.backends.s3boto3 import S3Boto3Storage
 
-from openedx.core.djangoapps.theming.storage import ThemeCachedFilesMixin, ThemePipelineMixin, ThemeMixin
+from openedx.core.djangoapps.theming.storage import ThemeManifestFilesMixin, ThemePipelineMixin, ThemeMixin
 
 
 class PipelineForgivingMixin(object):
@@ -44,7 +44,7 @@ class ProductionMixin(
         PipelineForgivingMixin,
         OptimizedFilesMixin,
         ThemePipelineMixin,
-        ThemeCachedFilesMixin,
+        ThemeManifestFilesMixin,
         ThemeMixin,
 ):
     """


### PR DESCRIPTION
## Description

This is a backport of edx/edx-platform#24990. The full context can be found on the original PR, but the gist of it is that some static files aren't being correctly served. The issue is specially noticeable when using a theme with translations on it.

## Testing instructions

* Check that the pages are being loaded correctly: LMS register is a good example and so is Studio home page.
  both need to load javascript to show correctly. 