### PR TITLE
Generate valid passwords when using additional validators

### DIFF
--- a/openedx/core/djangoapps/user_authn/utils.py
+++ b/openedx/core/djangoapps/user_authn/utils.py
@@ -125,17 +125,94 @@ def is_safe_login_or_logout_redirect(redirect_to, request_host, dot_client_id, r
     return is_safe_url
 
 
+def password_rules():
+    """
+    Inspect the validators defined in AUTH_PASSWORD_VALIDATORS and define
+    a rule list with the set of available characters and their minimum
+    for a specific charset category (alphabetic, digits, uppercase, etc).
+
+    This is based on the validators defined in
+    common.djangoapps.util.password_policy_validators and
+    django_password_validators.password_character_requirements.password_validation.PasswordCharacterValidator
+    """
+    password_validators = settings.AUTH_PASSWORD_VALIDATORS
+    rules = {
+        "alpha": [string.ascii_letters, 0],
+        "digit": [string.digits, 0],
+        "upper": [string.ascii_uppercase, 0],
+        "lower": [string.ascii_lowercase, 0],
+        "punctuation": [string.punctuation, 0],
+        "symbol": ["£¥€©®™†§¶πμ'±", 0],
+        "min_length": ["", 0],
+    }
+    options_mapping = {
+        "min_alphabetic": "alpha",
+        "min_length_alpha": "alpha",
+        "min_length_digit": "digit",
+        "min_length_upper": "upper",
+        "min_length_lower": "lower",
+        "min_lower": "lower",
+        "min_upper": "upper",
+        "min_numeric": "digit",
+        "min_symbol": "symbol",
+        "min_punctuation": "punctuation",
+    }
+
+    for validator in password_validators:
+        for option, mapping in options_mapping.items():
+            if not validator.get("OPTIONS"):
+                continue
+            rules[mapping][1] = max(
+                rules[mapping][1], validator["OPTIONS"].get(option, 0)
+            )
+        # We handle PasswordCharacterValidator separately because it can define
+        # its own set of special characters.
+        if (
+            validator["NAME"] ==
+            "django_password_validators.password_character_requirements.password_validation.PasswordCharacterValidator"
+        ):
+            min_special = validator["OPTIONS"].get("min_length_special", 0)
+            special_chars = validator["OPTIONS"].get(
+                "special_characters", "~!@#$%^&*()_+{}\":;'[]"
+            )
+            rules["special"] = [special_chars, min_special]
+
+    return rules
+
+
 def generate_password(length=12, chars=string.ascii_letters + string.digits):
-    """Generate a valid random password"""
+    """Generate a valid random password.
+
+    The original `generate_password` doesn't account for extra validators
+    This picks the minimum amount of characters for each charset category.
+    """
     if length < 8:
         raise ValueError("password must be at least 8 characters")
 
+    password = ""
+    password_length = length
     choice = random.SystemRandom().choice
+    rules = password_rules()
+    min_length = rules.pop("min_length")[1]
+    password_length = max(min_length, length)
 
-    password = ''
-    password += choice(string.digits)
-    password += choice(string.ascii_letters)
-    password += ''.join([choice(chars) for _i in range(length - 2)])
+    for rule, elems in rules.items():
+        choices = elems[0]
+        needed = elems[1]
+        for _ in range(needed):
+            next_char = choice(choices)
+            password += next_char
+
+    # fill the password to reach password_length
+    if len(password) < password_length:
+        password += "".join(
+            [choice(chars) for _ in range(password_length - len(password))]
+        )
+
+    password_list = list(password)
+    random.shuffle(password_list)
+
+    password = "".join(password_list)
     return password
 
 


### PR DESCRIPTION
## Description

When a user is created in the platform via a TPA provider, the platform uses the method `generate_password` to create the password for the user. The function [doesn't account for additional validators](https://github.com/openedx/edx-platform/pull/17954#discussion_r181457368) and will generate invalid passwords.

The implementation is a bit more cryptic than I would like. But what it does is check through each validator defined in `AUTH_PASSWORD_VALIDATORS` and list the minimum amount of characters of a specific type needed for a valid password. Then it builds the password starting with this minimum amount of characters and then fills the needed length with alphanumeric characters.

The name of options that map to certain characters (`min_alphabetic -> alpha`) are hard coded, and I assumed only validators found in [`common.djangoapps.util.password_policy_validators`](https://github.com/edunext/edx-platform/blob/mgs/generate-valid-passwords/common/djangoapps/util/password_policy_validators.py) and [`django-password-validators`](https://github.com/fizista/django-password-validators) will be used. It isn't as flexible as I would want, but is good enough for the time being.

## Testing instructions
Add an additional validator (i.e. special character) and try to create an account with a TPA provider. You should get an error saying the passwords needs x special characters. Try again with these changes and the process should complete without errors.