### PR TITLE
fix: icon on course outline was not showing correctly

### DIFF
--- a/openedx/features/course_experience/utils.py
+++ b/openedx/features/course_experience/utils.py
@@ -51,7 +51,7 @@ def get_course_outline_block_tree(request, course_id, user=None, allow_start_dat
         is_scored = block.get('has_score', False) and block.get('weight', 1) > 0
         # Use a list comprehension to force the recursion over all children, rather than just stopping
         # at the first child that is scored.
-        children_scored = any(recurse_mark_scored(child) for child in block.get('children', []))
+        children_scored = any([recurse_mark_scored(child) for child in block.get('children', [])])
         if is_scored or children_scored:
             block['scored'] = True
             return True


### PR DESCRIPTION
## Description

On the course outline, the icon for graded and scored problems was showing inconsistently. The cause was the parameter of the any() function a generator parameter that should be a list comprehension.
When the generator parameter was passed, only the first block that meets the condition was marked as scored. With this change now all blocks that meet the condition were marked as scored.

I'm not 100% sure how generators are treated 

## Supporting information

Link to other information about the change, such as Jira issues, GitHub issues, or Discourse discussions.
Be sure to check they are publicly readable, or if not, repeat the information here.

## Testing instructions

Please provide detailed step-by-step instructions for testing this change.

## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

Include anything else that will help reviewers and consumers understand the change.
- Does this change depend on other changes elsewhere?
- Any special concerns or limitations? For example: deprecations, migrations, security, or accessibility.
