### PR TITLE
fix: fix RTL text in editor of xblock problem.

### DIFF
--- a/common/lib/xmodule/xmodule/css/problem/edit.scss
+++ b/common/lib/xmodule/xmodule/css/problem/edit.scss
@@ -29,7 +29,7 @@
 .simple-editor-cheatsheet {
   position: absolute;
   top: 41px;
-  left: 70%;
+  @include left(70%);
   width: 0;
   border-left: 1px solid $gray-l2;
 


### PR DESCRIPTION
## Description
Fix overlap of the text editor with the simple editor cheatsheet in right to left orientation(RTL).

## Process
I suggest not to do padding, otherwise, I move the simple-editor-cheatshet to the left in order to preserve the order of RTL. 
Using saas mixins this change only apply in RTL cases.

**Before**:
![ltr1](https://user-images.githubusercontent.com/51926076/157903904-fc415c6f-461e-45b9-848c-01d4836ef599.png)
![ltr2](https://user-images.githubusercontent.com/51926076/157903894-5acfdfe7-522d-449e-99c9-a5aa85391fe8.png)

**After**:
![ltrf1](https://user-images.githubusercontent.com/51926076/157904959-29e3f722-4c1d-4d56-b84f-daca5d1e10e1.png)
![ltrf2](https://user-images.githubusercontent.com/51926076/157904954-2b7c7ad5-571c-4f91-9277-9cf608fa6cef.png)


## How to test
Checkout to this branch.
In devstack use, the command `make dev.static`.
Refresh your problem with an empty cache.
## Checklist for Merge

- [x]  Tested in local environment: devstack koa.
- [ ]  Tested in a remote environment:  
- [x]  Rebased limonero.master
- [x]  Squashed commits