### PR TITLE
Fix to prevent 500 error when course mode currency in NELP

### DIFF
--- a/common/djangoapps/course_modes/models.py
+++ b/common/djangoapps/course_modes/models.py
@@ -766,7 +766,10 @@ class CourseMode(models.Model):
         If there is no mode found, will return the price of DEFAULT_MODE, which is 0
         """
         modes = cls.modes_for_course(course_id)
-        return min(mode.min_price for mode in modes if mode.currency.lower() == currency.lower())
+        return min(
+            (mode.min_price for mode in modes if mode.currency.lower() == currency.lower()),
+            default=0
+        )
 
     @classmethod
     def is_eligible_for_certificate(cls, mode_slug, status=None):


### PR DESCRIPTION
# Description

Backport to avoid 500 errors in the course about page for Nelp.