### PR TITLE
fix: "Invalid type for parameter ContentType" error on js upload (#25…

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -23,9 +23,6 @@ django-countries==5.5
 # Removes deprecated get_ip function, which we still use (ARCHBOM-1329 for unpinning)
 django-ipware<3.0.0
 
-# 2.0.0 dropped support for Python 3.5
-django-pipeline<2.0.0
-
 # django-storages version 1.9 drops support for boto storage backend.
 django-storages<1.9
 

--- a/requirements/edx/base.txt
+++ b/requirements/edx/base.txt
@@ -68,8 +68,8 @@ django-multi-email-field==0.6.2  # via edx-enterprise
 django-mysql==3.9.0       # via -r requirements/edx/base.in
 django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
 django-object-actions==3.0.1  # via edx-enterprise
-django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
-django-pyfs==2.2          # via -r requirements/edx/base.in
+django-pipeline==2.0.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.in
+django-pyfs==3.0          # via -r requirements/edx/base.in
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/github.in
 django-ratelimit==3.0.1   # via -r requirements/edx/base.in
 django-require==1.0.11    # via -r requirements/edx/base.in

--- a/requirements/edx/development.txt
+++ b/requirements/edx/development.txt
@@ -79,8 +79,8 @@ django-multi-email-field==0.6.2  # via -r requirements/edx/testing.txt, edx-ente
 django-mysql==3.9.0       # via -r requirements/edx/testing.txt
 django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
 django-object-actions==3.0.1  # via -r requirements/edx/testing.txt, edx-enterprise
-django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
-django-pyfs==2.2          # via -r requirements/edx/testing.txt
+django-pipeline==2.0.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/testing.txt
+django-pyfs==3.0          # via -r requirements/edx/testing.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/testing.txt
 django-ratelimit==3.0.1   # via -r requirements/edx/testing.txt
 django-require==1.0.11    # via -r requirements/edx/testing.txt

--- a/requirements/edx/testing.txt
+++ b/requirements/edx/testing.txt
@@ -77,8 +77,8 @@ django-multi-email-field==0.6.2  # via -r requirements/edx/base.txt, edx-enterpr
 django-mysql==3.9.0       # via -r requirements/edx/base.txt
 django-oauth-toolkit==1.3.2  # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
 django-object-actions==3.0.1  # via -r requirements/edx/base.txt, edx-enterprise
-django-pipeline==1.7.0    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
-django-pyfs==2.2          # via -r requirements/edx/base.txt
+django-pipeline==2.0.5    # via -c requirements/edx/../constraints.txt, -r requirements/edx/base.txt
+django-pyfs==3.0          # via -r requirements/edx/base.txt
 git+https://github.com/edx/django-ratelimit-backend.git@v2.0.1a5#egg=django-ratelimit-backend==2.0.1a5  # via -r requirements/edx/base.txt
 django-ratelimit==3.0.1   # via -r requirements/edx/base.txt
 django-require==1.0.11    # via -r requirements/edx/base.txt


### PR DESCRIPTION
# Description
This issue allows to scorm not fail uploading js files.

This discussion is for scorm or upload js files  and the solution is related to django-pipeline package. Some advantages for upgrading but koa can use it.
The topic was treated by overhangio with the xblock.
https://github.com/overhangio/openedx-scorm-xblock/issues/16

## Error
```
73 63 6f 72 6d 2f 39 36 64 31 62 65 61 63 33 64 31 64 34 62
 65 62 62 38 30 39 31 32 32 64 65 63 37 66 64 65 63 32 2f 6
6 37 39 32 63 34 63 30 32 31 64 61 37 34 61 61 63 37 38 30 
65 30 37 32 62 66 31 36 61 61 30 65 64 34 39 38 37 37 36 37
 2f 45 74 69 71 75 65 74 74 65 2f 71 75 65 73 74 69 6f 6e 7
3 2e 6a 73</StringToSignBytes><RequestId>7N5G3F3EGFTCKWCA</
RequestId><HostId>h0KO5D6LjQM5yFz55JqS5JQMAPKAjjLB+nEfFk02g
MH3ybw6JLEUFk9bhdoeK4V/OoCJncQ28xU=</HostId></Error>
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-pac
^Mkages/boto/s3/key.py", line 748, in send_file^M    self._
send_file_internal(fp, headers=headers, cb=cb, nu^Mm_cb=num
_cb,^M  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/si
te-pac^Mkages/boto/s3/key.py", line 945, in _send_file_inte
rnal^M    resp = self.bucket.connection.make_request(^M  Fi
le "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-pac^Mka
ges/boto/s3/connection.py", line 661, in make_request^M    
return super(S3Connection, self).make_request(^M  File "/ed
x/app/edxapp/venvs/edxapp/lib/python3.8/site-pac^Mkages/bot
o/connection.py", line 1070, in make_request^M    return se
lf._mexe(http_request, sender, override_num_re^Mtries,^M  F
ile "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-pac^Mk
ages/boto/connection.py", line 939, in _mexe^M    response 
= sender(connection, request.method, request.p^Math,^M  Fil
e "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-pac^Mkag
es/boto/s3/key.py", line 883, in sender^M    raise provider
.storage_response_error(^Mboto.exception.S3ResponseError: S
3ResponseError: 403 Forbid^Mden^M<?xml version="1.0" encodi
ng="UTF-8"?>^M<Error><Code>SignatureDoesNotMatch</Code><Mes
sage>The reque^Mst signature we calculated does not match t
he signature you^M provided. Check your key and signing met
hod.</Message><AWS^MAccessKeyId>AKIA5O6PSRF7VHXMLQKW</AWSAc
cessKeyId><StringToS^Mign>PUT^Mlt7XHZXqdbMKxiUVP0ndeg==^Mte
xt/javascript^MThu, 16 Jun 2022 03:05:53 GMT^Mx-amz-acl:pri
vate^M/futurex-edxapp-production/scorm/96d1beac3d1d4bebb809
122dec^M7fdec2/f792c4c021da74aac780e072bf16aa0ed4987767/Eti
quette/q^Muestions.js</StringToSign><SignatureProvided>yNjo
xiKqAPGQki^M/lJJ4cORUJXds=</SignatureProvided><StringToSign
Bytes>50 55 ^M54 0a 6c 74 37 58 48 5a 58 71 64 62 4d 4b 78 
69 55 56 50 30^M 6e 64 65 67 3d 3d 0a 74 65 78 74 2f 6a 61 
76 61 73 63 72 6^M9 70 74 0a 54 68 75 2c 20 31 36 20 4a 75 
6e 20 32 30 32 32 ^M20 30 33 3a 30 35 3a 35 33 20 47 4d 54 
0a 78 2d 61 6d 7a 2d^M 61 63 6c 3a 70 72 69 76 61 74 65 0a 
2f 66 75 74 75 72 65 7^M8 2d 65 64 78 61 70 70 2d 70 72 6f 
64 75 63 74 69 6f 6e 2f ^M73 63 6f 72 6d 2f 39 36 64 31 62 
65 61 63 33 64 31 64 34 62^M 65 62 62 38 30 39 31 32 32 64 
65 63 37 66 64 65 63 32 2f 6^M6 37 39 32 63 34 63 30 32 31 
64 61 37 34 61 61 63 37 38 30 ^M65 30 37 32 62 66 31 36 61 
61 30 65 64 34 39 38 37 37 36 37^M 2f 45 74 69 71 75 65 74 
74 65 2f 71 75 65 73 74 69 6f 6e 7^M3 2e 6a 73</StringToSig
nBytes><RequestId>7N5G3F3EGFTCKWCA</^MRequestId><HostId>h0K
O5D6LjQM5yFz55JqS5JQMAPKAjjLB+nEfFk02g^MMH3ybw6JLEUFk9bhdoe
K4V/OoCJncQ28xU=</HostId></Error>^M

```

```
(Pdb) mimetypes.types_map['.js']    
b'text/javascript'                  
(Pdb) mimetypes.types_map['.js']    
b'text/javascript'                  
(Pdb) mimetypes.types_map['.js']    
b'text/javascript'                  

```

