### PR TITLE
LD-9: Remove preview and get urls for org

### DIFF
--- a/cms/djangoapps/contentstore/utils.py
+++ b/cms/djangoapps/contentstore/utils.py
@@ -103,7 +103,7 @@ def _remove_instructors(course_key):
         log.error(u"Error in deleting course groups for {0}: {1}".format(course_key, err))
 
 
-def get_lms_link_for_item(location, preview=False):
+def get_lms_link_for_item(location, preview=False):  # pylint: disable=unused-argument
     """
     Returns an LMS link to the course with a jump_to to the provided location.
 
@@ -122,15 +122,6 @@ def get_lms_link_for_item(location, preview=False):
 
     if lms_base is None:
         return None
-
-    if preview:
-        # checks PREVIEW_LMS_BASE value in site configuration for the given course_org_filter(org)
-        # if not found returns settings.FEATURES.get('PREVIEW_LMS_BASE')
-        lms_base = SiteConfiguration.get_value_for_org(
-            location.org,
-            "PREVIEW_LMS_BASE",
-            settings.FEATURES.get('PREVIEW_LMS_BASE')
-        )
 
     return u"//{lms_base}/courses/{course_key}/jump_to/{location}".format(
         lms_base=lms_base,

--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -593,7 +593,12 @@ def _get_asset_json(display_name, content_type, date, location, thumbnail_locati
     Helper method for formatting the asset information to send to client.
     '''
     asset_url = StaticContent.serialize_asset_key_with_slash(location)
-    external_url = settings.LMS_BASE + asset_url
+    lms_root = configuration_helpers.get_value_for_org(
+        location.org,
+        'LMS_ROOT_URL',
+        settings.LMS_ROOT_URL
+    )
+    external_url = lms_root + asset_url
     return {
         'display_name': display_name,
         'content_type': content_type,

--- a/cms/templates/container.html
+++ b/cms/templates/container.html
@@ -129,7 +129,7 @@ from openedx.core.djangolib.markup import HTML, Text
                             <span class="action-button-text">${_("View Live Version")}</span>
                         </a>
                     </li>
-                    <li class="action-item action-preview nav-item">
+                    <li class="action-item action-preview nav-item" style="display: none">
                         <a href="${draft_preview_link}" class="button button-preview action-button" rel="external" title="${_('Preview the courseware in the LMS')}">
                             <span class="action-button-text">${_("Preview")}</span>
                         </a>

--- a/common/djangoapps/util/course.py
+++ b/common/djangoapps/util/course.py
@@ -54,9 +54,15 @@ def get_link_for_about_page(course):
     elif settings.FEATURES.get('ENABLE_MKTG_SITE') and getattr(course, 'marketing_url', None):
         course_about_url = course.marketing_url
     else:
-        course_about_url = u'{about_base_url}/courses/{course_key}/about'.format(
-            about_base_url=configuration_helpers.get_value('LMS_ROOT_URL', settings.LMS_ROOT_URL),
-            course_key=six.text_type(course.id),
+        about_base = configuration_helpers.get_value_for_org(
+            course.id.org,
+            'LMS_ROOT_URL',
+            settings.LMS_ROOT_URL
+        )
+
+        course_about_url = '{about_base_url}/courses/{course_key}/about'.format(
+            about_base_url=about_base,
+            course_key=str(course.id),
         )
 
     return course_about_url


### PR DESCRIPTION
## Description

This is a cherry pick of https://github.com/eduNEXT/edunext-platform/pull/560/files

## Testing instructions

- Set LMS_ROOT_URL and course_org_filter in tenant config
- Go to Studio and access any of the courses with the same org set in the previous step 
- Go to “Settings” → “Schedule & Details” 
- Click on the Course Summary Page URL

Expected result: Redirect to the right tenant


