### PR TITLE
fix: solve import for helpers in content-store

### DIFF
--- a/cms/djangoapps/contentstore/views/assets.py
+++ b/cms/djangoapps/contentstore/views/assets.py
@@ -21,6 +21,7 @@ from six import text_type
 
 from common.djangoapps.edxmako.shortcuts import render_to_response
 from openedx.core.djangoapps.contentserver.caching import del_cached_content
+from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from common.djangoapps.student.auth import has_course_author_access
 from common.djangoapps.util.date_utils import get_default_time_display
 from common.djangoapps.util.json_request import JsonResponse


### PR DESCRIPTION
# Description
This is like a cherry pick of upstream for this file but only for the import of configuration helpers line.
https://github.com/eduNEXT/edx-platform/commit/c97932fa99d87b306d8c30372096867269525d1c#diff-0f34433c7178692a56d1130e46b7849de6e292cc69f7ffd56a33f3227705fa0aR26

This because  we cherry-picked https://github.com/eduNEXT/edx-platform/commit/aaf36f48eb2e620563be6854c8427bc5bd1fabeb there was a before commit that imported the helpers. For `configuration-helpers`:
https://github.com/eduNEXT/edx-platform/commit/aaf36f48eb2e620563be6854c8427bc5bd1fabeb#diff-0f34433c7178692a56d1130e46b7849de6e292cc69f7ffd56a33f3227705fa0aR596
## Jira story
https://edunext.atlassian.net/browse/NELP-232
## Sentry error
https://sentry.io/organizations/nelc-uk/issues/3537990235/?project=6402673&query=is%3Aunresolved
**Extra**:
Is already deployed in stage
## Before 
![Peek 2022-08-29 10-07](https://user-images.githubusercontent.com/51926076/187233996-258a8c3c-1bdd-42a2-b638-32694d9b8efe.gif)

## After 
![Peek 2022-08-29 11-41](https://user-images.githubusercontent.com/51926076/187251552-ecd5eed8-89af-478d-9bed-3aea39131370.gif)
