### PR TITLE
feat: control linked account by configuration helpers

### DIFF
--- a/lms/static/js/student_account/views/account_settings_factory.js
+++ b/lms/static/js/student_account/views/account_settings_factory.js
@@ -13,6 +13,7 @@
         return function(
             fieldsData,
             disableOrderHistoryTab,
+            showLinkedAccountsTab,
             ordersHistoryData,
             authData,
             passwordResetSupportUrl,
@@ -426,6 +427,7 @@
                 },
                 userPreferencesModel: userPreferencesModel,
                 disableOrderHistoryTab: disableOrderHistoryTab,
+                showLinkedAccountsTab: showLinkedAccountsTab,
                 betaLanguage: betaLanguage
             });
 

--- a/lms/static/js/student_account/views/account_settings_view.js
+++ b/lms/static/js/student_account/views/account_settings_view.js
@@ -37,15 +37,18 @@
                         selected: true,
                         expanded: true
                     },
-                    {
+                ];
+
+                if (view.options.showLinkedAccountsTab) {
+                    accountSettingsTabs.push({
                         name: 'accountsTabSections',
                         id: 'accounts-tab',
                         label: gettext('Linked Accounts'),
                         tabindex: -1,
                         selected: false,
                         expanded: false
-                    }
-                ];
+                    });
+                }
                 if (!view.options.disableOrderHistoryTab) {
                     accountSettingsTabs.push({
                         name: 'ordersTabSections',

--- a/lms/templates/student_account/account_settings.html
+++ b/lms/templates/student_account/account_settings.html
@@ -52,6 +52,7 @@ from openedx.core.djangoapps.user_api.accounts.utils import is_secondary_email_f
     AccountSettingsFactory(
         fieldsData,
         ${ disable_order_history_tab | n, dump_js_escaped_json },
+        ${ show_linked_accounts_tab | n, dump_js_escaped_json },
         ordersHistoryData,
         authData,
         '${ password_reset_support_link | n, js_escaped_string }',

--- a/openedx/core/djangoapps/user_api/accounts/settings_views.py
+++ b/openedx/core/djangoapps/user_api/accounts/settings_views.py
@@ -25,7 +25,8 @@ from openedx.core.djangoapps.programs.models import ProgramsApiConfig
 from openedx.core.djangoapps.site_configuration import helpers as configuration_helpers
 from openedx.core.djangoapps.user_api.accounts.toggles import (
     should_redirect_to_account_microfrontend,
-    should_redirect_to_order_history_microfrontend
+    should_redirect_to_order_history_microfrontend,
+    should_show_linked_accounts_tab
 )
 from openedx.core.djangoapps.user_api.preferences.api import get_user_preferences
 from openedx.core.lib.edx_api_utils import get_edx_api_data
@@ -139,6 +140,7 @@ def account_settings_context(request):
         'show_dashboard_tabs': True,
         'order_history': user_orders,
         'disable_order_history_tab': should_redirect_to_order_history_microfrontend(),
+        'show_linked_accounts_tab': should_show_linked_accounts_tab(),
         'enable_account_deletion': configuration_helpers.get_value(
             'ENABLE_ACCOUNT_DELETION', settings.FEATURES.get('ENABLE_ACCOUNT_DELETION', False)
         ),

--- a/openedx/core/djangoapps/user_api/accounts/toggles.py
+++ b/openedx/core/djangoapps/user_api/accounts/toggles.py
@@ -24,7 +24,10 @@ def should_redirect_to_order_history_microfrontend():
         REDIRECT_TO_ORDER_HISTORY_MICROFRONTEND.is_enabled()
     )
 
-
+def should_show_linked_accounts_tab():
+    return (
+        configuration_helpers.get_value('SHOW_LINKED_ACCOUNTS', True)
+    )
 # .. toggle_name: account.redirect_to_microfrontend
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False


### PR DESCRIPTION
# Description
This feature allows controlling the tab linked_accounts in account settings to appear or not.
It is controlled using `SHOW_LINKED_ACCOUNTS`.
Also, this allows control by tenant.
## Jira story 
https://edunext.atlassian.net/browse/NELP-234?atlOrigin=eyJpIjoiOGQ2NmNkZDcyOThkNDUxYThhODA3ZTg3M2M1OTFmZTQiLCJwIjoiaiJ9

## Before
The linked account is always on. 
![2022-09-02_12-06](https://user-images.githubusercontent.com/51926076/188203765-3ef9b18a-2124-48c0-8e46-19356fd3e9a5.png)


## After
**base theme**
![Peek 2022-09-02 12-01](https://user-images.githubusercontent.com/51926076/188203355-b3fc4116-0e68-4bcf-90f2-7d982886c48e.gif)

**Nelp theme**
Nelp theme needs this update
https://github.com/nelc/nelp-edx-theme/pull/99
![Peek 2022-09-02 11-42](https://user-images.githubusercontent.com/51926076/188200928-f81a2dad-8274-4088-81e0-c53a7ff1e599.gif)
