### PR TITLE
fix: handle missing forum account gracefully during user retirement

### DIFF
--- a/openedx/core/djangoapps/django_comment_common/comment_client/user.py
+++ b/openedx/core/djangoapps/django_comment_common/comment_client/user.py
@@ -1,10 +1,16 @@
 # pylint: disable=missing-docstring,protected-access
 """ User model wrapper for comment service"""
 
+import logging
+
+from django.db import IntegrityError
+
 from . import models, settings, utils
 from forum import api as forum_api
 from forum.utils import ForumV2RequestError, str_to_bool
 from openedx.core.djangoapps.discussions.config.waffle import is_forum_v2_enabled
+
+log = logging.getLogger(__name__)
 
 
 class User(models.Model):
@@ -237,7 +243,14 @@ class User(models.Model):
     def retire(self, retired_username):
         course_key = utils.get_course_key(self.attributes.get("course_id"))
         if is_forum_v2_enabled(course_key):
-            forum_api.retire_user(user_id=self.id, retired_username=retired_username, course_id=str(course_key))
+            try:
+                forum_api.retire_user(user_id=self.id, retired_username=retired_username, course_id=str(course_key))
+            except ForumV2RequestError:
+                # User has no forum account (never posted), so there is nothing to retire.
+                pass
+            except IntegrityError:
+                # Blank email already exists from a previously retired user. Log and continue.
+                log.warning("Forum retirement for user %s skipped due to duplicate email constraint.", self.id)
         else:
             url = _url_for_retire(self.id)
             params = {'retired_username': retired_username}


### PR DESCRIPTION
## Description

Two cases in the forum-v2 retirement path were causing a 500 and leaving the retirement pipeline stuck.

**Case 1: user with no forum account.** Users who have never posted have no forum record. `forum_api.retire_user()` raises `ForumV2RequestError("user not found")`, which was not being caught. The retirement endpoint returned 500, triggering the script's backoff-and-retry loop.

**Case 2: duplicate email constraint.** The forum MySQL backend sets `email=""` on `auth_user` during retirement. On deployments with a unique constraint on `auth_user.email`, retiring a second user fails with `IntegrityError: Duplicate entry '' for key 'auth_user.email'`. The LMS retirement pipeline generates a unique hashed email per user via [`get_retired_email_by_email`](https://github.com/edunext/edx-platform/blob/ednx-release/teak.campusagora/common/djangoapps/student/models/user.py#L287); the forum package doesn't. Not sure why this isn't tracked as an upstream issue already.

Both cases are now caught in [`User.retire()`](https://github.com/edunext/edx-platform/blob/MJG/catch-retirement-fail-as-404/openedx/core/djangoapps/django_comment_common/comment_client/user.py#L292) inside the forum-v2 path and treated as non-fatal. The retirement step completes and the pipeline continues.

## Supporting information

Root cause trace:

1. `POST /api/discussion/v1/accounts/retire_forum/` (retirement script)
2. [`RetireUserView.post()`](https://github.com/edunext/edx-platform/blob/ednx-release/teak.campusagora/lms/djangoapps/discussion/rest_api/views.py#L1135) in `discussion/rest_api/views.py`
3. [`comment_client.User.retire()`](https://github.com/edunext/edx-platform/blob/MJG/catch-retirement-fail-as-404/openedx/core/djangoapps/django_comment_common/comment_client/user.py#L292)
4. `forum_api.retire_user()` raises `ForumV2RequestError` (no forum account) or `IntegrityError` (duplicate blank email)

## Testing instructions

1. Create a user who has never posted in the forums.
2. Trigger user retirement via the pipeline or by calling `POST /api/discussion/v1/accounts/retire_forum/` directly with the service worker credentials.
3. Confirm the endpoint returns 204 instead of 500.
4. Confirm the retirement pipeline continues past the `RETIRING_FORUMS` step.
5. To test the duplicate email case: retire a second user after a first has already been retired successfully, on a deployment with a unique constraint on `auth_user.email`.

## Deadline

None.

## Other information

No migrations. No API contract changes. The endpoint's behavior for these two cases changes from 500 to 204.